### PR TITLE
ignore the build/ and dist/ directories created by setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.egg-info
 *.pyc
+build
+dist


### PR DESCRIPTION
setup.py creates build/ and dist/ directories in one's working copy, which `git status` then reports as untracked files. It should ignore them instead. Here's the trivial fix.
