### PR TITLE
put --build-id option into Daily Build option group, where it appears to belong

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -689,7 +689,7 @@ def cli():
                      default='mozilla-central',
                      metavar='BRANCH',
                      help='Name of the branch, default: "mozilla-central"')
-    parser.add_option('--build-id',
+    group.add_option('--build-id',
                       dest='build_id',
                       default=None,
                       metavar='BUILD_ID',


### PR DESCRIPTION
`--build-id` is daily build-specific, but right now `mozdownload --help` lists it as a general option. Here's the fix.
