### PR TITLE
re-fix build-id option group

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -691,7 +691,7 @@ def cli():
                      default='mozilla-central',
                      metavar='BRANCH',
                      help='Name of the branch, default: "%default"')
-    parser.add_option('--build-id',
+    group.add_option('--build-id',
                       dest='build_id',
                       default=None,
                       metavar='BUILD_ID',


### PR DESCRIPTION
D'oh! My B2G commit d6779b0f4530ffae95c1e65275818edaaea8b75d accidentally regressed the bug fix commit e44d57825dea0b817d2cdc10439c7aec333b23ed that you merged earlier in pull request #25. Here's the fix again.
