### PR TITLE
Don't download stub installer by default

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -267,8 +267,8 @@ class DailyScraper(Scraper):
                         'linux64': r'\.%(EXT)s$',
                         'mac': r'\.%(EXT)s$',
                         'mac64': r'\.%(EXT)s$',
-                        'win32': r'(\.installer)?\.%(EXT)s$',
-                        'win64': r'(\.installer)?\.%(EXT)s$'}
+                        'win32': r'(\.installer)\.%(EXT)s$',
+                        'win64': r'(\.installer)\.%(EXT)s$'}
         regex = regex_base_name + regex_suffix[self.platform]
 
         return regex % {'APP': self.application,


### PR DESCRIPTION
For now I can't fix beta and release because we don't know how the filename convention will look like.
