### PR TITLE
don't require Windows daily builds to have '.installer' in their names

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -287,8 +287,8 @@ class DailyScraper(Scraper):
                         'linux64': r'\.%(EXT)s$',
                         'mac': r'\.%(EXT)s$',
                         'mac64': r'\.%(EXT)s$',
-                        'win32': r'(\.installer)\.%(EXT)s$',
-                        'win64': r'(\.installer)\.%(EXT)s$'}
+                        'win32': r'(\.installer)?\.%(EXT)s$',
+                        'win64': r'(\.installer)?\.%(EXT)s$'}
         regex = regex_base_name + regex_suffix[self.platform]
 
         return regex % {'APP': self.application,


### PR DESCRIPTION
@whimboo: This is the separate pull request that reverts a change you made in [pull 31](https://github.com/mozilla/mozdownload/pull/31) that broke downloading of Windows B2G builds, which don't have an installer variant.

See for example this directory containing the most recent Windows build:

https://ftp.mozilla.org/pub/mozilla.org/b2g/nightly/2012/12/2012-12-13-09-53-19-mozilla-b2g18/

Presumably you made the change for a reason, though, and I don't want to break that other use case! Perhaps you can elaborate, and then we can figure out how to keep both working?
