### PR TITLE
Fix TypeError when download fails before temporary filename is constructed

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -194,7 +194,7 @@ class Scraper(object):
             os.rename(tmp_file, self.target)
         except:
             try:
-                if os.path.isfile(tmp_file):
+                if tmp_file and os.path.isfile(tmp_file):
                     os.remove(tmp_file)
             except OSError:
                 pass


### PR DESCRIPTION
The recent failures in the CI would give a more useful traceback if they weren't raising an exception when the temporary filename is None.
