### PR TITLE
Display version information (Fixes issue #34)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -19,14 +19,14 @@ import mozinfo
 from parser import DirectoryParser
 from timezones import PacificTimezone
 
-VERSION = pkg_resources.require("mozdownload")[0].version
+version = pkg_resources.require("mozdownload")[0].version
 
 __doc__= """
 Module to handle downloads for different types of ftp.mozilla.org hosted 
 applications.
 
 mozdownload version: %(version)s
-""" % {'version' : VERSION}
+""" % {'version' : version}
 
 APPLICATIONS = ['b2g', 'firefox', 'thunderbird']
 


### PR DESCRIPTION
I added to scraper.py

VERSION = pkg_resources.require("mozdownload")[0].version

in accordance with this article on stackoverflow

http://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package

because I was unsure what the accepted way of calling the version is. I couldn't find anything wrong with it. Hopefully, it's ok.

Thanks.
