### PR TITLE
Added urllib2.HTTPError to except clause in binary method

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -118,7 +118,7 @@ class Scraper(object):
                 print "Binary not found! Retrying... (attempt %s)" % attempt
                 if attempt >= self.retry_attempts:
                     raise NotFoundException("Binary not found in folder",
-                                        self.path)
+                                            self.path)
                 time.sleep(self.retry_delay)
 
         return self._binary


### PR DESCRIPTION
This Pull Request addresses issue #58 :

I have added urllib2.HTTPError to the try/except block in the method binary on line 117 and made sure the NotFoundException gets called in all instances in case the retry limit is exceeded.

@whimboo This fixes the issue that you have seen, but if you feel this is insufficient, then just as usual drop a line and give suggestions.

Thanks
