### PR TITLE
Add details of matching builds. Fixes issue #17

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -282,13 +282,13 @@ class Scraper(object):
         os.rename(tmp_file, self.target)
 
     def show_matching_builds(self, builds):
-        """Output the matching builds if there's more than one"""
-        if len(builds) > 1:
-            print 'Found %s builds: %s' % (
-                len(builds),
-                len(builds) > 10 and
-                ' ... '.join([', '.join(builds[:5]), ', '.join(builds[-5:])]) or
-                ', '.join(builds))
+        """Output the matching builds"""
+        print 'Found %s build%s: %s' % (
+            len(builds),
+            len(builds) > 1 and 's' or '',
+            len(builds) > 10 and
+            ' ... '.join([', '.join(builds[:5]), ', '.join(builds[-5:])]) or
+            ', '.join(builds))
 
 
 class DailyScraper(Scraper):


### PR DESCRIPTION
Less than 10 matches:

> $ mozdownload -t tinderbox --date=2013-04-08
> Retrieving list of builds from https://ftp.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/mozilla-central-macosx64
> Found 3 builds: 1365415768, 1365465695, 1365477812
> Downloading from: https://ftp.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/mozilla-central-macosx64/1365477812/firefox-23.0a1.en-US.mac.dmg

More than 10 matches:

> $ mozdownload -t tinderbox
> Retrieving list of builds from https://ftp.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/mozilla-central-macosx64
> Found 143 builds: 1362910146, 1362957227, 1362971147, 1362996586, 1363019027 ... 1365627905, 1365637809, 1365674965, 1365693248, 1365708064
> Downloading from: https://ftp.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/mozilla-central-macosx64/1365708064/firefox-23.0a1.en-US.mac.dmg
