### PR TITLE
Issue #77, support hidden candidates directories

### DIFF
--- a/mozdownload/parser.py
+++ b/mozdownload/parser.py
@@ -13,15 +13,11 @@ import urllib2
 class DirectoryParser(HTMLParser):
     """Class to parse directory listings"""
 
-    def __init__(self, url, opener=None):
+    def __init__(self, url):
         HTMLParser.__init__(self)
 
         self.entries = [ ]
         self.active_url = None
-
-        # handle authentication
-        if opener is not None:
-            urllib2.install_opener(opener)
 
         req = urllib2.urlopen(url, timeout=60)
         self.feed(req.read())

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -113,7 +113,7 @@ class Scraper(object):
             attempt += 1
             try:
                 # Retrieve all entries from the remote virtual folder
-                parser = DirectoryParser(self.path, self.opener)
+                parser = DirectoryParser(self.path)
                 if not parser.entries:
                     raise NotFoundException('No entries found', self.path)
 
@@ -299,7 +299,7 @@ class DailyScraper(Scraper):
             url = '%s/nightly/latest-%s/' % (self.base_url, self.branch)
 
             print 'Retrieving the build status file from %s' % url
-            parser = DirectoryParser(url, self.opener)
+            parser = DirectoryParser(url)
             parser.entries = parser.filter(r'.*%s\.txt' % self.platform_regex)
             if not parser.entries:
                 message = 'Status file for %s build cannot be found' % self.platform_regex
@@ -317,7 +317,7 @@ class DailyScraper(Scraper):
         url = '/'.join([self.base_url, self.monthly_build_list_regex])
 
         print 'Retrieving list of builds from %s' % url
-        parser = DirectoryParser(url, self.opener)
+        parser = DirectoryParser(url)
         regex = r'%(DATE)s-(\d+-)+%(BRANCH)s%(L10N)s$' % {
                     'DATE': date.strftime('%Y-%m-%d'),
                     'BRANCH': self.branch,
@@ -475,7 +475,7 @@ class ReleaseCandidateScraper(ReleaseScraper):
         url = '/'.join([self.base_url, self.candidate_build_list_regex])
 
         print 'Retrieving list of candidate builds from %s' % url
-        parser = DirectoryParser(url, self.opener)
+        parser = DirectoryParser(url)
         if not parser.entries:
             message = 'Folder for specific candidate builds at has not been found'
             raise NotFoundException(message, url)
@@ -670,7 +670,7 @@ class TinderboxScraper(Scraper):
         # If a timestamp is given, retrieve just that build
         regex = '^' + self.timestamp + '$' if self.timestamp else r'^\d+$'
 
-        parser = DirectoryParser(url, self.opener)
+        parser = DirectoryParser(url)
         parser.entries = parser.filter(regex)
 
         # If date is given, retrieve the subset of builds on that date


### PR DESCRIPTION
- allows DirectoryParser to use auth by passing in an urllib2 opener
- move creation of urllib2 opener to Scraper.**init** to share it between scraper.py and DirectoryParser. NB uses self.base_url rather than self.final_url
- if --build-number is passed for candidates then don't parse the parent directory for it, otherwise go look up the latest (public) dir
- fix up saved filename for above change

Testing: I've looked at the candidates case only:

```
# don't give a build-number or auth, find the latest public dir
$ mozdownload --type candidate --platform mac --locale de --version 21.0 --directory builds
Retrieving list of candidate builds from https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/21.0-candidates/
Downloading from: https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/21.0-candidates/build3/mac/de/Firefox 21.0.dmg
# builds/firefox-21.0-build3.de.mac.dmg

# get a hidden dir by passing build-number and auth (fake auth)
$ mozdownload --type candidate --platform mac --locale de --version 21.0 --directory builds --build-number 2 --username=### --password=###
Downloading from: https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/21.0-candidates/build2/mac/de/Firefox 21.0.dmg
# builds/firefox-21.0-build2.de.mac.dmg

# get an older public build by specifying build-number
$ mozdownload --type candidate --platform mac --locale de --version 21.0 --directory builds --build-number 1
Downloading from: https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/21.0-candidates/build1/mac/de/Firefox 21.0.dmg
# builds/firefox-21.0-build1.de.mac.dmg
```
