### PR TITLE
Remove default value of 180s for timeout option (#91) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Run `mozdownload --help` for detailed information on the command line options.
       --retry-delay=RETRY_DELAY
                               Amount of time (in seconds) to wait between retry attempts,
                               default: 10
-      --timeout=TIMEOUT       Amount of time (in seconds) until download times out, default: 0
+      --timeout=TIMEOUT       Amount of time (in seconds) until download times out
 
       Candidate builds:       Extra options for candidate builds.
 

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -245,7 +245,7 @@ class Scraper(object):
                         pbar.update(bytes_downloaded)
 
                         t1 = total_seconds(datetime.now() - start_time)
-                        if self.timeout_download is not None and \
+                        if self.timeout_download and \
                                 t1 >= self.timeout_download:
                             raise TimeoutError
                 pbar.finish()


### PR DESCRIPTION
This addresses issue #91

Simple change of timeout from 180. to 0. and an adjustment of the README.
