### PR TITLE
Carry on to "first tests"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 build
 dist
+tests/venv

--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ Run `mozdownload --help` for detailed information on the command line options.
 
       --debug-build           Download a debug build
 
+
+## Running the tests
+
+To run the tests, run `./run_tests.sh`.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+VERSION_MANIFEST_DESTINY=0.5.6
+VERSION_MOZTEST=0.1
+VERSION_MOZFILE=0.7
+VERSION_VIRTUAL_ENV=1.9.1
+ 
+VENV_DIR="tests/venv"
+ 
+# Check if environment exists, if not, create a virtualenv:
+if [ -d $VENV_DIR ]
+then
+echo "Using virtual environment in $VENV_DIR"
+else
+echo "Creating a virtual environment (version ${VERSION_VIRTUAL_ENV}) in ${VENV_DIR}"
+curl https://raw.github.com/pypa/virtualenv/${VERSION_VIRTUAL_ENV}/virtualenv.py | python - --no-site-packages $VENV_DIR
+fi
+. $VENV_DIR/bin/activate
+ 
+python setup.py develop
+pip install --upgrade ManifestDestiny==$VERSION_MANIFEST_DESTINY
+pip install --upgrade moztest==$VERSION_MOZTEST
+pip install --upgrade mozfile==$VERSION_MOZFILE
+ 
+python tests/test.py $@

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except (OSError, IOError):
 
 version = '1.8'
 
-deps = ['mozinfo==0.3.3', 'progressbar==2.2', 'requests==1.2.2']
+deps = ['mozinfo==0.6', 'progressbar==2.2', 'requests==1.2.2']
 
 setup(name='mozdownload',
       version=version,

--- a/tests/direct_scraper/manifest.ini
+++ b/tests/direct_scraper/manifest.ini
@@ -1,0 +1,1 @@
+[test_direct_scraper.py]

--- a/tests/direct_scraper/test_direct_scraper.py
+++ b/tests/direct_scraper/test_direct_scraper.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import tempfile
+import unittest
+
+import mozfile
+
+from mozdownload import DirectScraper, NotImplementedError
+
+
+class TestDirectScraper(unittest.TestCase):
+    """test mozdownload direct url scraper"""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        mozfile.rmtree(self.temp_dir)
+
+    def test_url_download(self):
+        test_url = 'https://mozqa.com/index.html'
+        scraper = DirectScraper(url=test_url,
+                                directory=self.temp_dir,
+                                version=None)
+        self.assertEqual(scraper.url, test_url)
+        self.assertEqual(scraper.final_url, test_url)
+        self.assertEqual(scraper.target,
+                         os.path.join(self.temp_dir, 'index.html'))
+
+        for attr in ['binary', 'binary_regex', 'path', 'path_regex']:
+            self.assertRaises(NotImplementedError, getattr, scraper, attr)
+
+        scraper.download()
+        self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
+                                                    scraper.target)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/manifest.ini
+++ b/tests/manifest.ini
@@ -1,0 +1,1 @@
+[include:direct_scraper/manifest.ini]

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import imp
+import os
+import sys
+import unittest
+
+from manifestparser import TestManifest
+from moztest.results import TestResultCollection
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_tests(path):
+    """return the unittests in a .py file"""
+
+    path = os.path.abspath(path)
+    unittests = []
+    assert os.path.exists(path)
+    modname = os.path.splitext(os.path.basename(path))[0]
+    module = imp.load_source(modname, path)
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(module)
+    for test in suite:
+        unittests.append(test)
+    return unittests
+
+
+def test_all(manifest):
+    print "\n#################"
+    print "# Running tests #"
+    print "#################\n"
+    # gather the tests
+    tests = manifest.active_tests(disabled=False)
+    unittestlist = []
+    for test in tests:
+        unittestlist.extend(get_tests(test['path']))
+
+    # run the tests
+    suite = unittest.TestSuite(unittestlist)
+    # default=1 does not show success of unittests
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest_results = runner.run(suite)
+    return unittest_results
+
+
+def main(args=sys.argv[1:]):
+
+    # read the manifest
+    if args:
+        manifests = args
+    else:
+        manifests = [os.path.join(here, 'manifest.ini')]
+    missing = []
+    for manifest_file in manifests:
+        # ensure manifests exist
+        if not os.path.exists(manifest_file):
+            missing.append(manifest_file)
+    assert not missing, 'manifest%s not found: %s' % (
+        (len(manifests) == 1 and '' or 's'), ', '.join(missing))
+    manifest = TestManifest(manifests=manifests)
+    unittest_results = test_all(manifest)
+    results = TestResultCollection.from_unittest_results(
+        None, unittest_results)
+
+    # exit according to results
+    sys.exit(1 if results.num_failures else 0)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I asked Dave to let me have a go at this. With his help I added script for running the tests automatically and I added another puny little test to it.

Regarding line 50 (missing.append) and whimboo's question if manifestparser does the checks already (from the previous pull):

```
I just had a look at the TestManifest class of manifestparser.py and it's true it makes checks if a test exists, but unlike here, it just ignores it, if the test doesn't exist.

https://github.com/mozilla/mozbase/blob/master/manifestdestiny/manifestparser/manifestparser.py#l750
```

I assume that is the reason for this line.
