### PR TITLE
Fallback to domain name if downloading from an URL without specifying a path (#89)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -13,6 +13,7 @@ import requests
 import sys
 import time
 import urllib
+from urlparse import urlparse
 
 import mozinfo
 
@@ -446,9 +447,8 @@ class DirectScraper(Scraper):
 
     @property
     def target(self):
-        from urlparse import urlparse
         target = urlparse(self.final_url)
-        return target.path.rpartition('/')[-1] or target.netloc
+        return target.path.rpartition('/')[-1] or target.hostname
 
     @property
     def final_url(self):


### PR DESCRIPTION
Example output:

``` bash
$ mozdownload --url=http://mozqa.com
Traceback (most recent call last):
  File "/Users/dhunt/.virtualenvs/mozdownload/bin/mozdownload", line 8, in <module>
    load_entry_point('mozdownload==1.7.2', 'console_scripts', 'mozdownload')()
  File "/Users/dhunt/workspace/mozdownload/mozdownload/scraper.py", line 939, in cli
    build.download()
  File "/Users/dhunt/workspace/mozdownload/mozdownload/scraper.py", line 233, in download
    if os.path.isfile(os.path.abspath(self.target)):
  File "/Users/dhunt/workspace/mozdownload/mozdownload/scraper.py", line 452, in target
    raise NotFoundError('There is no file to be downloaded', self.final_url)
mozdownload.scraper.NotFoundError: There is no file to be downloaded: http://mozqa.com
```
