### PR TITLE
Add Travis-CI configuration for running the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - 2.7
+script: ./run_tests.sh
+notifications:
+  email:
+    - dev-automation@lists.mozilla.org
+  irc:
+    - "irc.mozilla.org#automation"


### PR DESCRIPTION
You can see the latest result here: https://travis-ci.org/davehunt/mozdownload/builds/10417725

We may want to use a different e-mail address for notifications. What do you think @whimboo? At the moment I configured it to use the same as mozbase.

At the moment, the IRC notifications will not work due to https://github.com/travis-ci/travis-ci/issues/436
