### PR TITLE
Give user instructions when calling mozdownload without arguments (#150)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -26,7 +26,7 @@ import progressbar
 version = pkg_resources.require("mozdownload")[0].version
 
 __doc__ = """
-Module to handle downloads for different types of ftp.mozilla.org hosted
+Module to handle downloads for different types of ftp.mozilla.org hosted \
 applications.
 
 mozdownload version: %(version)s


### PR DESCRIPTION
This pull address issue #150.

I tried to go off what whimboo said in the issue discussion and create a short and comprehensive message on what to do when the user calls mozdownload without any arguments.
