### PR TITLE
Show found candidate builds when build number is given (#148)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -557,14 +557,11 @@ class ReleaseCandidateScraper(ReleaseScraper):
         "Defines additional build information"
 
         # Internally we access builds via index
+        self.builds, self.build_index = self.get_build_info_for_version(
+            self.version)
         if self.build_number is not None:
-            self.builds, self.build_index = self.get_build_info_for_version(
-                self.version)
             self.builds = ['build%s' % self.build_number]
             self.build_index = 0
-        else:
-            self.builds, self.build_index = self.get_build_info_for_version(
-                self.version)
 
     def get_build_info_for_version(self, version, build_index=None):
         url = urljoin(self.base_url, self.candidate_build_list_regex)


### PR DESCRIPTION
This pull address issue #148 

This was a rather simple fix. `self.get_build_info_for_version` was just not called in the if option where a build-number had to be specified.
