### PR TITLE
Added stub support for TinderboxScraper (#180)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -702,14 +702,15 @@ class TinderboxScraper(Scraper):
                         'linux64': r'.*\.%(EXT)s$',
                         'mac': r'.*\.%(EXT)s$',
                         'mac64': r'.*\.%(EXT)s$',
-                        'win32': r'.*(\.installer)\.%(EXT)s$',
-                        'win64': r'.*(\.installer)\.%(EXT)s$'}
+                        'win32': r'.*(\.installer%(STUB)s)\.%(EXT)s$',
+                        'win64': r'.*(\.installer%(STUB)s)\.%(EXT)s$'}
 
         regex = regex_base_name + regex_suffix[self.platform]
 
         return regex % {'APP': self.application,
                         'LOCALE': self.locale,
                         'PLATFORM': PLATFORM_FRAGMENTS[self.platform],
+                        'STUB': '-stub' if self.is_stub_installer else '',
                         'EXT': self.extension}
 
     def build_filename(self, binary):

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -30,6 +30,13 @@ firefox_tests = [
      'target': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'target_url': 'firefox/tinderbox-builds/mozilla-central-win32/'
                    '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
+    # -a firefox -p win32 --stub
+    {'args': {'application': 'firefox',
+              'platform': 'win32',
+              'is_stub_installer': True},
+     'target': 'mozilla-central-firefox-25.0a1.en-US.win32.installer-stub.exe',
+     'target_url': 'firefox/tinderbox-builds/mozilla-central-win32/'
+                   '1374583608/firefox-25.0a1.en-US.win32.installer-stub.exe'},
     # -a firefox -p linux --branch=mozilla-central
     {'args': {'branch': 'mozilla-central',
               'platform': 'linux'},


### PR DESCRIPTION
This PR addresses issue #180

I added support for stub installers on a windows platform.

The current latest tinderbox folder for windows does not have a stub installer. At the time of writing this a suitable test for functionality would be

`mozdownload -t tinderbox -p win32 --date=1382263322 --stub`

This will however change after awhile.
