### PR TITLE
Check if self.timestamp in method build_filename is really of date type and not just a string (#196)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -359,8 +359,10 @@ class DailyScraper(Scraper):
         elif self.date:
             # A date (without time) has been specified. Use its value and the
             # build index to find the requested build for that day.
-            self.date = datetime.strptime(self.date, '%Y-%m-%d')
-
+            try:
+                self.date = datetime.strptime(self.date, '%Y-%m-%d')
+            except:
+                raise ValueError('%s is not a valid date' % self.date)
         else:
             # If no build id nor date have been specified the latest available
             # build of the given branch has to be identified. We also have to
@@ -690,8 +692,12 @@ class TinderboxScraper(Scraper):
                 # date is provided in the format 2013-07-23
                 self.date = datetime.strptime(self.date, '%Y-%m-%d')
             except:
-                # date is provided as a unix timestamp
-                self.timestamp = self.date
+                try:
+                    # date is provided as a unix timestamp
+                    datetime.fromtimestamp(float(self.date))
+                    self.timestamp = self.date
+                except:
+                    raise ValueError('%s is not a valid date' % self.date)
 
         self.locale_build = self.locale != 'en-US'
         # For localized builds we do not have to retrieve the list of builds
@@ -973,7 +979,7 @@ def cli():
     # Check for required options and arguments
     # Note: Will be optional when ini file support has been landed
     if not options.url \
-       and not options.type in ['daily', 'tinderbox'] \
+       and options.type not in ['daily', 'tinderbox'] \
        and not options.version:
         parser.error('The version of the application to download has not'
                      ' been specified.')

--- a/tests/daily_scraper/manifest.ini
+++ b/tests/daily_scraper/manifest.ini
@@ -1,1 +1,4 @@
 [test_daily_scraper.py]
+[test_invalid_date.py]
+
+

--- a/tests/daily_scraper/test_invalid_date.py
+++ b/tests/daily_scraper/test_invalid_date.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import mozlog
+import sys
+import unittest
+import urllib
+
+from mozdownload import DailyScraper
+from mozdownload.utils import urljoin
+
+import mozhttpd_base_test as mhttpd
+
+
+# testing with an invalid date parameter should raise an error
+tests_with_invalid_date = [
+    # -p win32 --branch=mozilla-central --date=20140317030202
+    {'args': {'branch': 'mozilla-central',
+              'date': '20140317030202',
+              'locale': 'pt-PT',
+              'platform': 'win32'}
+    },
+    # -p win32 --branch=mozilla-central  --date=1960-07-23
+     {'args': {'branch': 'mozilla-central',
+              'date': '1960-07-23',
+              'locale': 'pt-PT',
+              'platform': 'win32'}
+     },
+    # -p win64 --branch=mozilla-central --date=2013/07/02
+     {'args': {'branch': 'mozilla-central',
+              'date': '2013/07/02',
+              'platform': 'win64'},
+     },
+    # -p win32 --branch=mozilla-central --date=2013-March-15
+    {'args': {'branch': 'mozilla-central',
+              'date': '2013-March-15',
+              'platform': 'win32'},
+    }
+]
+
+tests = tests_with_invalid_date
+
+
+class TestDailyScraper_invalidParameters(mhttpd.MozHttpdBaseTest):
+    """test mozdownload DailyScraper class with invalid parameters"""
+
+    def test_scraper(self):
+        """Testing download scenarios with invalid parameters for DailyScraper"""
+
+        for entry in tests:
+            with self.assertRaises(ValueError):
+                DailyScraper(directory=self.temp_dir, version=None,
+                             base_url=self.wdir, log_level='ERROR',
+                             **entry['args'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tinderbox_scraper/manifest.ini
+++ b/tests/tinderbox_scraper/manifest.ini
@@ -1,1 +1,3 @@
 [test_tinderbox_scraper.py]
+[test_invalid_date.py]
+

--- a/tests/tinderbox_scraper/test_invalid_date.py
+++ b/tests/tinderbox_scraper/test_invalid_date.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import mozlog
+import sys
+import unittest
+import urllib
+
+from mozdownload import TinderboxScraper
+from mozdownload import NotFoundError
+from mozdownload.utils import urljoin
+
+import mozhttpd_base_test as mhttpd
+
+
+# testing with an invalid date parameter should download the latest build for
+# localized builds
+tests_with_invalid_date = [
+    # -a firefox -p win32 --branch=mozilla-central --date=20140317030202
+    {'args': {'application': 'firefox',
+              'branch': 'mozilla-central',
+              'date': '20140317030202',
+              'locale': 'pt-PT',
+              'platform': 'win32'}
+    },
+    # -p win32 --branch=mozilla-central  --date=invalid
+    {'args': {'branch': 'mozilla-central',
+              'date': 'invalid',
+              'locale': 'pt-PT',
+              'platform': 'win32'}
+    },
+    # -p win64 --branch=mozilla-central --date=2013/07/02
+    {'args': {'branch': 'mozilla-central',
+              'date': '2013/07/02',
+              'platform': 'win64'},
+    },
+    # -p win32 --branch=mozilla-central --date=2013-March-15
+    {'args': {'branch': 'mozilla-central',
+              'date': '2013-March-15',
+              'platform': 'win32'},
+    }
+]
+
+tests = tests_with_invalid_date
+
+
+class TestTinderboxScraper_invalidParameters(mhttpd.MozHttpdBaseTest):
+    """test mozdownload TinderboxScraper class with invalid parameters"""
+
+    def test_scraper(self):
+        """Testing download scenarios with invalid parameters for TinderboxScraper"""
+
+        for entry in tests:
+            with self.assertRaises(ValueError):
+                TinderboxScraper(directory=self.temp_dir, version=None,
+                                 base_url=self.wdir, log_level='ERROR',
+                                 **entry['args'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We check that the self.timestamp is of int type and not just a string when we save the build.
This way we avoid saving the build with "$DATE" at the beginning.
https://bugzilla.mozilla.org/show_bug.cgi?id=962011  
