### PR TITLE
Release version 1.11 (#203)

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+1.11 / 2014-02-03
+=================
+
+  * Adjust mozbase package dependencies to be more flexible (#201)
+  * Log the name of the output file for discovery (#199)
+  * Changed logger info level in tests to ERROR (#175)
+  * PEP8 fixes in test_daily_scraper (#188)
+
 1.10 / 2013-11-19
 =================
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ try:
 except (OSError, IOError):
     description = None
 
-version = '1.10'
+version = '1.11'
 
 # Load dependencies
 with open('requirements.txt') as f:


### PR DESCRIPTION
This patch bumps mozdownload to 1.11 and updates the version history. It fixes #203
