### PR TITLE
Add Python 2.6 to test matrix (#210)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "2.7"
 install:
   - pip install pep8
-  - python --version
 before_script:
   - "pep8 mozdownload"
 script: ./run_tests.py

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -309,7 +309,7 @@ class Scraper(object):
                     os.remove(tmp_file)
                 if self.retry_attempts > 0:
                     # Log only if multiple attempts are requested
-                    self.logger.warning('Download failed: "%s"' % e.message)
+                    self.logger.warning('Download failed: "%s"' % str(e))
                     self.logger.info('Will retry in %s seconds...' %
                                      (self.retry_delay))
                     time.sleep(self.retry_delay)

--- a/tests/daily_scraper/test_invalid_date.py
+++ b/tests/daily_scraper/test_invalid_date.py
@@ -52,10 +52,12 @@ class TestDailyScraper_invalidParameters(mhttpd.MozHttpdBaseTest):
         """Testing download scenarios with invalid parameters for DailyScraper"""
 
         for entry in tests:
-            with self.assertRaises(ValueError):
-                DailyScraper(directory=self.temp_dir, version=None,
-                             base_url=self.wdir, log_level='ERROR',
-                             **entry['args'])
+            self.assertRaises(ValueError, DailyScraper,
+                              directory=self.temp_dir,
+                              version=None,
+                              base_url=self.wdir,
+                              log_level='ERROR',
+                              **entry['args'])
 
 
 if __name__ == '__main__':

--- a/tests/tinderbox_scraper/test_invalid_date.py
+++ b/tests/tinderbox_scraper/test_invalid_date.py
@@ -55,10 +55,12 @@ class TestTinderboxScraper_invalidParameters(mhttpd.MozHttpdBaseTest):
         """Testing download scenarios with invalid parameters for TinderboxScraper"""
 
         for entry in tests:
-            with self.assertRaises(ValueError):
-                TinderboxScraper(directory=self.temp_dir, version=None,
-                                 base_url=self.wdir, log_level='ERROR',
-                                 **entry['args'])
+            self.assertRaises(ValueError, TinderboxScraper,
+                              directory=self.temp_dir,
+                              version=None,
+                              base_url=self.wdir,
+                              log_level='ERROR',
+                              **entry['args'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We should be compatible with Python 2.6. So lets get the tests also running with that version.
