### PR TITLE
Localized b2g desktop builds cannot be found (#224)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -98,13 +98,11 @@ class Scraper(object):
         self._binary = None
 
         self.directory = directory
-        if not locale:
-            if application in MULTI_LOCALE_APPLICATIONS:
-                self.locale = 'multi'
-            else:
-                self.locale = 'en-US'
+
+        if application in MULTI_LOCALE_APPLICATIONS:
+            self.locale = 'multi' if locale != 'en-US' else 'en-US'
         else:
-            self.locale = locale
+            self.locale = locale or 'en-US'
 
         self.platform = platform or self.detect_platform()
         self.version = version

--- a/tests/daily_scraper/test_daily_scraper.py
+++ b/tests/daily_scraper/test_daily_scraper.py
@@ -238,28 +238,28 @@ b2g_tests = [
               'branch': 'mozilla-central'},
     'target': '2014-01-12-04-02-02-mozilla-central-b2g-29.0a1.multi.linux-i686.tar.bz2',
     'target_url': 'b2g/nightly/2014/01/2014-01-12-04-02-02-mozilla-central/b2g-29.0a1.multi.linux-i686.tar.bz2'
-     },
+    },
     # -p linux64 --branch=mozilla-central
     {'args': {'application': 'b2g',
               'platform': 'linux64',
               'branch': 'mozilla-central'},
     'target': '2014-01-12-04-02-02-mozilla-central-b2g-29.0a1.multi.linux-x86_64.tar.bz2',
     'target_url': 'b2g/nightly/2014/01/2014-01-12-04-02-02-mozilla-central/b2g-29.0a1.multi.linux-x86_64.tar.bz2'
-     },
+    },
     # -p mac64 --branch=mozilla-central
     {'args': {'application': 'b2g',
               'platform': 'mac64',
               'branch': 'mozilla-central'},
     'target': '2014-01-12-04-02-02-mozilla-central-b2g-29.0a1.multi.mac64.dmg',
     'target_url': 'b2g/nightly/2014/01/2014-01-12-04-02-02-mozilla-central/b2g-29.0a1.multi.mac64.dmg'
-     },
-    # -p mac64 --branch=mozilla-central
+    },
+    # -p win32 --branch=mozilla-central
     {'args': {'application': 'b2g',
               'platform': 'win32',
               'branch': 'mozilla-central'},
     'target': '2014-01-12-04-02-02-mozilla-central-b2g-29.0a1.multi.win32.zip',
     'target_url': 'b2g/nightly/2014/01/2014-01-12-04-02-02-mozilla-central/b2g-29.0a1.multi.win32.zip'
-     },
+    },
     # -p win32 --branch=mozilla-central -l en-US
     {'args': {'application': 'b2g',
               'platform': 'win32',
@@ -267,7 +267,15 @@ b2g_tests = [
               'locale': 'en-US'},
     'target': '2014-01-12-04-02-02-mozilla-central-b2g-29.0a1.en-US.win32.zip',
     'target_url': 'b2g/nightly/2014/01/2014-01-12-04-02-02-mozilla-central/en-US/b2g-29.0a1.en-US.win32.zip'
-     },
+    },
+    # -p win32 --branch=mozilla-central -l de
+    {'args': {'application': 'b2g',
+              'platform': 'win32',
+              'branch': 'mozilla-central',
+              'locale': 'de'},
+    'target': '2014-01-12-04-02-02-mozilla-central-b2g-29.0a1.multi.win32.zip',
+    'target_url': 'b2g/nightly/2014/01/2014-01-12-04-02-02-mozilla-central/b2g-29.0a1.multi.win32.zip'
+    },
     # -p win32 --branch=mozilla-central --date=2013-07-01
     {'args': {'application': 'b2g',
               'platform': 'win32',
@@ -275,7 +283,7 @@ b2g_tests = [
               'date': '2013-07-01'},
     'target': '2013-07-01-04-02-02-mozilla-central-b2g-29.0a1.multi.win32.zip',
     'target_url': 'b2g/nightly/2013/07/2013-07-01-04-02-02-mozilla-central/b2g-29.0a1.multi.win32.zip'
-     },
+    },
     # -p win32 --branch=mozilla-central --date=2013-07-01 --build-number=1
     {'args': {'application': 'b2g',
               'platform': 'win32',
@@ -284,7 +292,7 @@ b2g_tests = [
               'build_number': 1},
     'target': '2013-07-01-04-01-01-mozilla-central-b2g-29.0a1.multi.win32.zip',
     'target_url': 'b2g/nightly/2013/07/2013-07-01-04-01-01-mozilla-central/b2g-29.0a1.multi.win32.zip'
-     },
+    },
     # -p linux --branch=mozilla-central --build-id=20130702031336
     {'args': {'application': 'b2g',
               'platform': 'linux',
@@ -292,7 +300,7 @@ b2g_tests = [
               'build_id': '20130702031336'},
     'target': '2013-07-02-03-13-36-mozilla-central-b2g-29.0a1.multi.linux-i686.tar.bz2',
     'target_url': 'b2g/nightly/2013/07/2013-07-02-03-13-36-mozilla-central/b2g-29.0a1.multi.linux-i686.tar.bz2'
-     }
+    }
 ]
 
 tests = firefox_tests + thunderbird_tests + b2g_tests


### PR DESCRIPTION
This fixes issue #224 by always defaulting to `multi`, and not using the specified locale for multi-locale applications.
