### PR TITLE
Auth as (None, None) should default to None

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -108,7 +108,10 @@ class Scraper(object):
 
         self.platform = platform or self.detect_platform()
         self.version = version
-        self.authentication = authentication
+        if authentication == (None, None):
+            self.authentication = None
+        else:
+            self.authentication = authentication
         self.retry_attempts = retry_attempts
         self.retry_delay = retry_delay
         self.is_stub_installer = is_stub_installer

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -89,8 +89,10 @@ class Scraper(object):
 
     def __init__(self, directory, version, platform=None,
                  application='firefox', locale=None, extension=None,
-                 username=None, password=None, retry_attempts=0, retry_delay=10.,
-                 is_stub_installer=False, timeout=None, log_level='INFO',
+                 username=None, password=None,
+                 retry_attempts=0, retry_delay=10.,
+                 is_stub_installer=False, timeout=None,
+                 log_level='INFO',
                  base_url=BASE_URL):
 
         # Private properties for caching

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -89,7 +89,7 @@ class Scraper(object):
 
     def __init__(self, directory, version, platform=None,
                  application='firefox', locale=None, extension=None,
-                 authentication=None, retry_attempts=0, retry_delay=10.,
+                 username=None, password=None, retry_attempts=0, retry_delay=10.,
                  is_stub_installer=False, timeout=None, log_level='INFO',
                  base_url=BASE_URL):
 
@@ -108,10 +108,10 @@ class Scraper(object):
 
         self.platform = platform or self.detect_platform()
         self.version = version
-        if authentication == (None, None):
+        if (username, password) == (None, None):
             self.authentication = None
         else:
-            self.authentication = authentication
+            self.authentication = (username, password)
         self.retry_attempts = retry_attempts
         self.retry_delay = retry_delay
         self.is_stub_installer = is_stub_installer
@@ -1037,7 +1037,8 @@ def cli():
                         'version': options.version,
                         'directory': options.directory,
                         'extension': options.extension,
-                        'authentication': (options.username, options.password),
+                        'username': options.username,
+                        'password': options.password,
                         'retry_attempts': options.retry_attempts,
                         'retry_delay': options.retry_delay,
                         'is_stub_installer': options.is_stub_installer,

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -74,5 +74,40 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
         self.assertRaises(mozdownload.NotImplementedError,
                           scraper.build_filename, 'invalid binary')
 
+    def test_authentication(self):
+        # testing authentication
+        username = 'mozilla'
+        password = 'mozilla'
+        basic_auth_url = 'http://mozqa.com/data/mozqa.com/http_auth/basic/'
+        no_auth_url = 'https://ci.mozilla.org/' #does not need auth
+
+        # test with invalid authentication
+        # check if exception is thrown
+        scraper = mozdownload.DirectScraper(directory=self.temp_dir,
+                                      url = basic_auth_url,
+                                      version=None,
+                                      log_level='ERROR')
+        self.assertRaises(requests.exceptions.HTTPError,scraper.download)
+
+        # testing with valid authentication
+        scraper = mozdownload.DirectScraper(directory=self.temp_dir,
+                                      url = basic_auth_url,
+                                      version=None,
+                                      log_level='ERROR',
+                                      username=username,
+                                      password=password)
+        print self.temp_dir
+        scraper.download()
+        self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
+                                                    'mozqa.com')))
+        # test with a site that requires no authentication
+        scraper = mozdownload.DirectScraper(directory=self.temp_dir,
+                                      url = no_auth_url,
+                                      version=None,
+                                      log_level='ERROR')
+        scraper.download()
+        self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
+                                                    'ci.mozilla.org')))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -75,7 +75,7 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
                           scraper.build_filename, 'invalid binary')
 
     def test_authentication(self):
-        # testing authentication
+        """testing authentication"""
         username = 'mozilla'
         password = 'mozilla'
         basic_auth_url = 'http://mozqa.com/data/mozqa.com/http_auth/basic/'
@@ -84,27 +84,27 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
         # test with invalid authentication
         # check if exception is thrown
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
-                                      url = basic_auth_url,
-                                      version=None,
-                                      log_level='ERROR')
+                                            url = basic_auth_url,
+                                            version=None,
+                                            log_level='ERROR')
         self.assertRaises(requests.exceptions.HTTPError,scraper.download)
 
         # testing with valid authentication
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
-                                      url = basic_auth_url,
-                                      version=None,
-                                      log_level='ERROR',
-                                      username=username,
-                                      password=password)
+                                            url = basic_auth_url,
+                                            version=None,
+                                            log_level='ERROR',
+                                            username=username,
+                                            password=password)
         print self.temp_dir
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'mozqa.com')))
         # test with a site that requires no authentication
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
-                                      url = no_auth_url,
-                                      version=None,
-                                      log_level='ERROR')
+                                            url = no_auth_url,
+                                            version=None,
+                                            log_level='ERROR')
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'ci.mozilla.org')))

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -75,35 +75,35 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
                           scraper.build_filename, 'invalid binary')
 
     def test_authentication(self):
-        """testing authentication"""
+        """testing with basic authentication"""
         username = 'mozilla'
         password = 'mozilla'
         basic_auth_url = 'http://mozqa.com/data/mozqa.com/http_auth/basic/'
-        no_auth_url = 'https://ci.mozilla.org/' #does not need auth
 
         # test with invalid authentication
-        # check if exception is thrown
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
                                             url = basic_auth_url,
-                                            version=None,
-                                            log_level='ERROR')
+                                            version=None)
         self.assertRaises(requests.exceptions.HTTPError,scraper.download)
 
         # testing with valid authentication
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
                                             url = basic_auth_url,
                                             version=None,
-                                            log_level='ERROR',
                                             username=username,
                                             password=password)
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'mozqa.com')))
-        # test with a site that requires no authentication
+
+    def test_optional_authenticaiton(self):
+        """testing with optional basic authentication"""
+        optional_auth_url = 'https://ci.mozilla.org/'
+
+        # requires optional authentication with no data specified
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
-                                            url = no_auth_url,
-                                            version=None,
-                                            log_level='ERROR')
+                                            url = optional_auth_url,
+                                            version=None)
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'ci.mozilla.org')))

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -85,13 +85,15 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
         # test with invalid authentication
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
                                             url=basic_auth_url,
-                                            version=None)
+                                            version=None,
+                                            log_level='ERROR')
         self.assertRaises(requests.exceptions.HTTPError, scraper.download)
 
         # testing with valid authentication
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
                                             url=basic_auth_url,
                                             version=None,
+                                            log_level='ERROR',
                                             username=username,
                                             password=password)
         scraper.download()
@@ -105,7 +107,8 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
         # requires optional authentication with no data specified
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
                                             url=optional_auth_url,
-                                            version=None)
+                                            version=None,
+                                            log_level='ERROR')
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'ci.mozilla.org')))

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -98,7 +98,7 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'mozqa.com')))
 
-    def test_optional_authenticaiton(self):
+    def test_optional_authentication(self):
         """testing with optional basic authentication"""
         optional_auth_url = 'https://ci.mozilla.org/'
 

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -96,7 +96,6 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
                                             log_level='ERROR',
                                             username=username,
                                             password=password)
-        print self.temp_dir
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'mozqa.com')))

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -41,7 +41,9 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     filename)))
         # Compare original and downloaded file via md5 hash
-        md5_original = create_md5(os.path.join(mhttpd.HERE, mhttpd.WDIR, filename))
+        md5_original = create_md5(os.path.join(mhttpd.HERE,
+                                               mhttpd.WDIR,
+                                               filename))
         md5_downloaded = create_md5(os.path.join(self.temp_dir, filename))
         self.assertEqual(md5_original, md5_downloaded)
 
@@ -82,13 +84,13 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
 
         # test with invalid authentication
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
-                                            url = basic_auth_url,
+                                            url=basic_auth_url,
                                             version=None)
-        self.assertRaises(requests.exceptions.HTTPError,scraper.download)
+        self.assertRaises(requests.exceptions.HTTPError, scraper.download)
 
         # testing with valid authentication
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
-                                            url = basic_auth_url,
+                                            url=basic_auth_url,
                                             version=None,
                                             username=username,
                                             password=password)
@@ -102,7 +104,7 @@ class BaseScraperTest(mhttpd.MozHttpdBaseTest):
 
         # requires optional authentication with no data specified
         scraper = mozdownload.DirectScraper(directory=self.temp_dir,
-                                            url = optional_auth_url,
+                                            url=optional_auth_url,
                                             version=None)
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,


### PR DESCRIPTION
@whimboo 
This is an attempt to fix #195 
 > We should provide None for the auth argument rather than a tuple with None values.