### PR TITLE
Catch KeyboardInterrupt exception

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -1069,7 +1069,7 @@ def cli():
     try:
         build.download()
     except KeyboardInterrupt:
-        print "Download interrupted by the user"
+        print "\n", "Download interrupted by the user"
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Added an exception catch so when we abort mozdownload while it's downloading a file you no longer see a full stack for the KeyboardInterrupt exception.
