### PR TITLE
Make mac and mac64 platform equivalent for tinderbox builds (#215)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -756,7 +756,6 @@ class TinderboxScraper(Scraper):
         regex_suffix = {'linux': r'.*\.%(EXT)s$',
                         'linux64': r'.*\.%(EXT)s$',
                         'mac': r'.*\.%(EXT)s$',
-                        'mac64': r'.*\.%(EXT)s$',
                         'win32': r'.*(\.installer%(STUB)s)\.%(EXT)s$',
                         'win64': r'.*(\.installer%(STUB)s)\.%(EXT)s$'}
 
@@ -863,7 +862,6 @@ class TinderboxScraper(Scraper):
         PLATFORM_FRAGMENTS = {'linux': 'linux',
                               'linux64': 'linux64',
                               'mac': 'macosx',
-                              'mac64': 'macosx64',
                               'win32': 'win32',
                               'win64': 'win64'}
 

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -863,7 +863,7 @@ class TinderboxScraper(Scraper):
         PLATFORM_FRAGMENTS = {'linux': 'linux',
                               'linux64': 'linux64',
                               'mac': r'macosx(64)?',
-                              'mac64': r'macosx(64)?',
+                              'mac64': 'macosx64',
                               'win32': 'win32',
                               'win64': 'win64'}
 

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -862,7 +862,7 @@ class TinderboxScraper(Scraper):
 
         PLATFORM_FRAGMENTS = {'linux': 'linux',
                               'linux64': 'linux64',
-                              'mac': r'macosx(64)?',
+                              'mac': 'macosx64',
                               'mac64': 'macosx64',
                               'win32': 'win32',
                               'win64': 'win64'}

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -756,6 +756,7 @@ class TinderboxScraper(Scraper):
         regex_suffix = {'linux': r'.*\.%(EXT)s$',
                         'linux64': r'.*\.%(EXT)s$',
                         'mac': r'.*\.%(EXT)s$',
+                        'mac64': r'.*\.%(EXT)s$',
                         'win32': r'.*(\.installer%(STUB)s)\.%(EXT)s$',
                         'win64': r'.*(\.installer%(STUB)s)\.%(EXT)s$'}
 
@@ -861,7 +862,8 @@ class TinderboxScraper(Scraper):
 
         PLATFORM_FRAGMENTS = {'linux': 'linux',
                               'linux64': 'linux64',
-                              'mac': 'macosx',
+                              'mac': r'macosx(64)?',
+                              'mac64': r'macosx(64)?',
                               'win32': 'win32',
                               'win64': 'win64'}
 

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -63,6 +63,13 @@ firefox_tests = [
      'target': 'mozilla-central-firefox-25.0a1.en-US.win64-x86_64.installer.exe',
      'target_url': 'firefox/tinderbox-builds/mozilla-central-win64/'
                    '1374583608/firefox-25.0a1.en-US.win64-x86_64.installer.exe'},
+    # -a firefox -p mac64 --branch=mozilla-central
+    {'args': {'application': 'firefox',
+              'branch': 'mozilla-central',
+              'platform': 'mac64'},
+     'target': 'mozilla-central-firefox-25.0a1.en-US.mac.dmg',
+     'target_url': 'firefox/tinderbox-builds/mozilla-central-macosx64/'
+                   '1374583608/firefox-25.0a1.en-US.mac.dmg'},
     # -a firefox -p win32 --branch=mozilla-central --debug-build
     {'args': {'application': 'firefox',
               'branch': 'mozilla-central',
@@ -144,6 +151,13 @@ thunderbird_tests = [
      'target': 'comm-central-thunderbird-27.0a1.en-US.linux-x86_64.tar.bz2',
      'target_url': 'thunderbird/tinderbox-builds/comm-central-linux64/'
                    '1380362686/thunderbird-27.0a1.en-US.linux-x86_64.tar.bz2'},
+    # -a thunderbird -p mac64 --branch=comm-central
+    {'args': {'application': 'thunderbird',
+              'branch': 'comm-central',
+              'platform': 'mac64'},
+     'target': 'comm-central-thunderbird-27.0a1.en-US.mac.dmg',
+     'target_url': 'thunderbird/tinderbox-builds/comm-central-macosx64/'
+                   '1380362686/thunderbird-27.0a1.en-US.mac.dmg'},
     # -a thunderbird -p win32 --branch=comm-central
     {'args': {'application': 'thunderbird',
               'branch': 'comm-central',

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -63,13 +63,6 @@ firefox_tests = [
      'target': 'mozilla-central-firefox-25.0a1.en-US.win64-x86_64.installer.exe',
      'target_url': 'firefox/tinderbox-builds/mozilla-central-win64/'
                    '1374583608/firefox-25.0a1.en-US.win64-x86_64.installer.exe'},
-    # -a firefox -p mac64 --branch=mozilla-central
-    {'args': {'application': 'firefox',
-              'branch': 'mozilla-central',
-              'platform': 'mac64'},
-     'target': 'mozilla-central-firefox-25.0a1.en-US.mac.dmg',
-     'target_url': 'firefox/tinderbox-builds/mozilla-central-macosx64/'
-                   '1374583608/firefox-25.0a1.en-US.mac.dmg'},
     # -a firefox -p win32 --branch=mozilla-central --debug-build
     {'args': {'application': 'firefox',
               'branch': 'mozilla-central',
@@ -151,13 +144,6 @@ thunderbird_tests = [
      'target': 'comm-central-thunderbird-27.0a1.en-US.linux-x86_64.tar.bz2',
      'target_url': 'thunderbird/tinderbox-builds/comm-central-linux64/'
                    '1380362686/thunderbird-27.0a1.en-US.linux-x86_64.tar.bz2'},
-    # -a thunderbird -p mac64 --branch=comm-central
-    {'args': {'application': 'thunderbird',
-              'branch': 'comm-central',
-              'platform': 'mac64'},
-     'target': 'comm-central-thunderbird-27.0a1.en-US.mac.dmg',
-     'target_url': 'thunderbird/tinderbox-builds/comm-central-macosx64/'
-                   '1380362686/thunderbird-27.0a1.en-US.mac.dmg'},
     # -a thunderbird -p win32 --branch=comm-central
     {'args': {'application': 'thunderbird',
               'branch': 'comm-central',


### PR DESCRIPTION
This PR addresses issue #215 

From what I can gather, this issue is a simple deletion job, so I just took out the necessary parts in `scraper.py` and in the tests.