### PR TITLE
Tinderbox builds: If latest folder is empty go to newest folder with build (#143)

### DIFF
--- a/tests/data/firefox/tinderbox-builds/mozilla-central-linux/1374583609/README.md
+++ b/tests/data/firefox/tinderbox-builds/mozilla-central-linux/1374583609/README.md
@@ -1,0 +1,3 @@
+This is supposed to be an empty directory to serve as a test case for a missing binary.
+
+See Issue #143 "TinderboxScraper: Omit folders without binaries"


### PR DESCRIPTION
This PR addresses issue #143 

I essentially followed the fix for Issue #11 and transferred the `DailyScraper`'s `self.is_buid_dir` function to the `TinderboxScraper`.

I left the line starting with `self.application...` in, in case we will at one point fully support b2g downloads.