### PR TITLE
Limit checks for non-empty build dirs (#253)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -872,7 +872,6 @@ class TinderboxScraper(Scraper):
         parser = DirectoryParser(url, authentication=self.authentication,
                                  timeout=self.timeout_network)
         parser.entries = parser.filter(r'^\d+$')
-        parser.entries = parser.filter(self.is_build_dir)
 
         if self.timestamp:
             # If a timestamp is given, retrieve the folder with the timestamp
@@ -892,7 +891,13 @@ class TinderboxScraper(Scraper):
 
         # If no index has been given, set it to the last build of the day.
         if build_index is None:
-            build_index = len(parser.entries) - 1
+            # Find the most recent non-empty entry.
+            build_index = len(parser.entries)
+            for build in reversed(parser.entries):
+                build_index -= 1
+                if not build_index or self.is_build_dir(build):
+                    break
+
         self.logger.info('Selected build: %s' % parser.entries[build_index])
 
         return (parser.entries, build_index)


### PR DESCRIPTION
Checking if a build dir is empty is an expensive operation. This
iteratively checks for a non-empty build dir only when necessary and
stops checking when the first non-empty build dir is found.