### PR TITLE
 mozdownload cannot load tinderbox zip builds for Windows

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -782,8 +782,8 @@ class TinderboxScraper(Scraper):
                         'linux64': r'.*\.%(EXT)s$',
                         'mac': r'.*\.%(EXT)s$',
                         'mac64': r'.*\.%(EXT)s$',
-                        'win32': r'.*(\.installer%(STUB)s)\.%(EXT)s$',
-                        'win64': r'.*(\.installer%(STUB)s)\.%(EXT)s$'}
+                        'win32': r'(\.installer%(STUB)s)?\.%(EXT)s$',
+                        'win64': r'(\.installer%(STUB)s)?\.%(EXT)s$'}
 
         regex = regex_base_name + regex_suffix[self.platform]
 


### PR DESCRIPTION
@whimboo - Please review. This addresses issue #258.

Have the regular expressions for the windows binaries match the ones used for release.