### PR TITLE
Display correct build number on download without choosing specific candidate build (#232)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -639,7 +639,9 @@ class ReleaseCandidateScraper(ReleaseScraper):
             self.build_index = 0
             self.logger.info('Selected build: build%s' % self.build_number)
         else:
-            self.logger.info('Selected build: build%s' % self.build_index)
+            # Otherwise displays incorrect build number
+            display_index = str(int(self.build_index) + 1)
+            self.logger.info('Selected build: build%s' % display_index)
 
     def get_build_info_for_version(self, version, build_index=None):
         url = urljoin(self.base_url, self.candidate_build_list_regex)

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -639,7 +639,8 @@ class ReleaseCandidateScraper(ReleaseScraper):
             self.build_index = 0
             self.logger.info('Selected build: build%s' % self.build_number)
         else:
-            self.logger.info('Selected build: build%d' % (self.build_index + 1))
+            self.logger.info('Selected build: build%d' %
+                            (self.build_index + 1))
 
     def get_build_info_for_version(self, version, build_index=None):
         url = urljoin(self.base_url, self.candidate_build_list_regex)

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -640,7 +640,7 @@ class ReleaseCandidateScraper(ReleaseScraper):
             self.logger.info('Selected build: build%s' % self.build_number)
         else:
             self.logger.info('Selected build: build%d' %
-                            (self.build_index + 1))
+                             (self.build_index + 1))
 
     def get_build_info_for_version(self, version, build_index=None):
         url = urljoin(self.base_url, self.candidate_build_list_regex)

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -639,9 +639,7 @@ class ReleaseCandidateScraper(ReleaseScraper):
             self.build_index = 0
             self.logger.info('Selected build: build%s' % self.build_number)
         else:
-            # Otherwise displays incorrect build number
-            display_index = str(int(self.build_index) + 1)
-            self.logger.info('Selected build: build%s' % display_index)
+            self.logger.info('Selected build: build%d' % (self.build_index + 1))
 
     def get_build_info_for_version(self, version, build_index=None):
         url = urljoin(self.base_url, self.candidate_build_list_regex)


### PR DESCRIPTION
Addresses issue #232 

Turned out the buildnumber displayed in downloads was always one too low.