### PR TITLE
Directory iteration optimization

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -464,7 +464,6 @@ class DailyScraper(Scraper):
             # ensure to select the correct subfolder for localized builds
             'L10N': '' if self.locale in ('en-US', 'multi') else '(-l10n)?'}
         parser.entries = parser.filter(regex)
-        parser.entries = parser.filter(self.is_build_dir)
 
         if has_time:
             # If a time is included in the date, use it to determine the
@@ -478,11 +477,21 @@ class DailyScraper(Scraper):
                 self.date.strftime(date_format)
             raise NotFoundError(message, url)
 
-        # If no index has been given, set it to the last build of the day.
+        # If no index has been given, set it to the last directory of the day that has a build.
         self.show_matching_builds(parser.entries)
         if build_index is None:
-            build_index = len(parser.entries) - 1
-        self.logger.info('Selected build: %s' % parser.entries[build_index])
+            for index in reversed(range(len(parser.entries))):
+                if self.is_build_dir(parser.entries[index]):
+                    build_index = index
+                    self.logger.info('Selected build: %s' % parser.entries[build_index])
+                    break
+
+        if build_index is None:
+            date_format = '%Y-%m-%d-%H-%M-%S' if has_time else '%Y-%m-%d'
+            message = 'Folder for builds on %s has not been found' % \
+                self.date.strftime(date_format)
+            raise NotFoundError(message, url)
+
 
         return (parser.entries, build_index)
 
@@ -782,8 +791,8 @@ class TinderboxScraper(Scraper):
                         'linux64': r'.*\.%(EXT)s$',
                         'mac': r'.*\.%(EXT)s$',
                         'mac64': r'.*\.%(EXT)s$',
-                        'win32': r'.*(\.installer%(STUB)s)\.%(EXT)s$',
-                        'win64': r'.*(\.installer%(STUB)s)\.%(EXT)s$'}
+                        'win32': r'(\.installer%(STUB)s)?\.%(EXT)s$',
+                        'win64': r'(\.installer%(STUB)s)?\.%(EXT)s$'}
 
         regex = regex_base_name + regex_suffix[self.platform]
 
@@ -872,7 +881,6 @@ class TinderboxScraper(Scraper):
         parser = DirectoryParser(url, authentication=self.authentication,
                                  timeout=self.timeout_network)
         parser.entries = parser.filter(r'^\d+$')
-        parser.entries = parser.filter(self.is_build_dir)
 
         if self.timestamp:
             # If a timestamp is given, retrieve the folder with the timestamp
@@ -890,10 +898,20 @@ class TinderboxScraper(Scraper):
 
         self.show_matching_builds(parser.entries)
 
-        # If no index has been given, set it to the last build of the day.
+        # If no index has been given, set it to the last directory of the day that has a build.
         if build_index is None:
-            build_index = len(parser.entries) - 1
-        self.logger.info('Selected build: %s' % parser.entries[build_index])
+            for index in reversed(range(len(parser.entries))):
+                if self.is_build_dir(parser.entries[index]):
+                    build_index = index
+                    self.logger.info('Selected build: %s' % parser.entries[build_index])
+                    break
+            if build_index is None:
+                message = 'No builds have been found'
+                raise NotFoundError(message, url)
+        else:
+            if not self.is_build_dir(parser.entries[build_index]):
+                message = 'No builds have been found'
+                raise NotFoundError(message, url)
 
         return (parser.entries, build_index)
 

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -912,7 +912,7 @@ class TinderboxScraper(Scraper):
 
         PLATFORM_FRAGMENTS = {'linux': 'linux',
                               'linux64': 'linux64',
-                              'mac': 'macosx',
+                              'mac': 'macosx64',
                               'mac64': 'macosx64',
                               'win32': 'win32',
                               'win64': 'win64'}

--- a/tests/daily_scraper/test_daily_scraper.py
+++ b/tests/daily_scraper/test_daily_scraper.py
@@ -43,6 +43,16 @@ firefox_tests = [
     'target_url': 'firefox/nightly/2013/10/2013-10-01-03-02-04-mozilla-central/firefox-27.0a1.en-US.win64-x86_64.installer.exe'
    },
 
+    # -p win32 --branch=mozilla-central --date 2013-10-01 --extension=txt
+    {'args': {'platform': 'win32',
+              'branch': 'mozilla-central',
+              'date': '2013-10-01',
+              'extension': 'txt'},
+    'target': '2013-10-01-03-02-04-mozilla-central-firefox-27.0a1.en-US.win32.txt',
+    'target_url': 'firefox/nightly/2013/10/2013-10-01-03-02-04-mozilla-central/firefox-27.0a1.en-US.win32.txt'
+    },
+
+
     # -p linux --branch=mozilla-central
     {'args': {'platform': 'linux',
                'branch': 'mozilla-central'},

--- a/tests/data/firefox/nightly/2013/10/2013-10-01-03-02-04-mozilla-central/firefox-27.0a1.en-US.win32.txt
+++ b/tests/data/firefox/nightly/2013/10/2013-10-01-03-02-04-mozilla-central/firefox-27.0a1.en-US.win32.txt
@@ -1,0 +1,2 @@
+20131001030204
+http://hg.mozilla.org/mozilla-central/rev/6b92cb377496

--- a/tests/data/firefox/tinderbox-builds/mozilla-beta-macosx64/1424896038/firefox-37.0.en-US.mac.txt
+++ b/tests/data/firefox/tinderbox-builds/mozilla-beta-macosx64/1424896038/firefox-37.0.en-US.mac.txt
@@ -1,0 +1,2 @@
+20150225122718
+https://hg.mozilla.org/releases/mozilla-beta/rev/b23a690fa325

--- a/tests/data/firefox/tinderbox-builds/mozilla-beta-win32/1424726083/firefox-37.0.en-US.win32.txt
+++ b/tests/data/firefox/tinderbox-builds/mozilla-beta-win32/1424726083/firefox-37.0.en-US.win32.txt
@@ -1,0 +1,2 @@
+20150223131443
+https://hg.mozilla.org/releases/mozilla-beta/rev/192f6746dc45

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -142,6 +142,7 @@ firefox_tests = [
      'target': 'mozilla-central-firefox-25.0a1.en-US.linux-i686.txt',
      'target_url': 'firefox/tinderbox-builds/mozilla-central-linux/'
                    '1374583608/firefox-25.0a1.en-US.linux-i686.txt'},
+    # -a firefox -t tinderbox -p win32 --branch=mozilla-beta --extension=txt
     {'args': {'application': 'firefox',
               'branch': 'mozilla-beta',
               'extension': 'txt',
@@ -149,7 +150,14 @@ firefox_tests = [
      'target': 'mozilla-beta-firefox-37.0.en-US.win32.txt',
      'target_url': 'firefox/tinderbox-builds/mozilla-beta-win32/'
                    '1424726083/firefox-37.0.en-US.win32.txt'},
-
+    # -a firefox -t tinderbox -p mac --branch=mozilla-beta --extension=txt
+    {'args': {'application': 'firefox',
+              'branch': 'mozilla-beta',
+              'extension': 'txt',
+              'platform': 'mac'},
+     'target': 'mozilla-beta-firefox-37.0.en-US.mac.txt',
+     'target_url': 'firefox/tinderbox-builds/mozilla-beta-macosx64/'
+                   '1424896038/firefox-37.0.en-US.mac.txt'},
 ]
 
 thunderbird_tests = [

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -142,6 +142,14 @@ firefox_tests = [
      'target': 'mozilla-central-firefox-25.0a1.en-US.linux-i686.txt',
      'target_url': 'firefox/tinderbox-builds/mozilla-central-linux/'
                    '1374583608/firefox-25.0a1.en-US.linux-i686.txt'},
+    {'args': {'application': 'firefox',
+              'branch': 'mozilla-beta',
+              'extension': 'txt',
+              'platform': 'win32'},
+     'target': 'mozilla-beta-firefox-37.0.en-US.win32.txt',
+     'target_url': 'firefox/tinderbox-builds/mozilla-beta-win32/'
+                   '1424726083/firefox-37.0.en-US.win32.txt'},
+
 ]
 
 thunderbird_tests = [


### PR DESCRIPTION
This patch redoes the test for empty directories in tinderbox builds. Rather than iterate over every directory (which often causes the server to cut me off when I try to download a beta build), test the latest directory, then the next latest, etc, until a build is found.
Similar work with the DailyScraper.

Add tests for --type=tinderbox -p win32 --extension

This requires and subsumes the patch in pull request #259.

@whimboo Please review, 