### PR TITLE
Connection close

### DIFF
--- a/mozdownload/parser.py
+++ b/mozdownload/parser.py
@@ -28,6 +28,7 @@ class DirectoryParser(HTMLParser):
                          headers=headers, timeout=self.timeout)
         r.raise_for_status()
         self.feed(r.text)
+        r.close()
 
     def filter(self, filter):
         """Filter entries by calling function or applying regex."""

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -431,7 +431,9 @@ class DailyScraper(Scraper):
                          auth=self.authentication, headers=headers)
         r.raise_for_status()
 
-        return datetime.strptime(r.text.split('\n')[0], '%Y%m%d%H%M%S')
+        retval = datetime.strptime(r.text.split('\n')[0], '%Y%m%d%H%M%S')
+        r.close()
+        return relval
 
     def is_build_dir(self, dir):
         """Return whether or not the given dir contains a build."""


### PR DESCRIPTION
When we traverse directories in ftp.mozilla.org, we don't close the http connection. In urllib, at least on some platforms, when you close a connection, it will be reused. Without this, it is easy to flood ftp.mozilla.org with connections, and if you are not on Mozilla's network, ftp.mozilla.org will start returning 503 Server Too Busy errors.