### PR TITLE
build now given '-stub' suffix on download where appropriate (#167)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -625,7 +625,8 @@ class ReleaseScraper(Scraper):
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary"""
 
-        template = '%(APP)s-%(VERSION)s.%(LOCALE)s.%(PLATFORM)s%(STUB)s.%(EXT)s'
+        template = '%(APP)s-%(VERSION)s.%(LOCALE)s.%(PLATFORM)s%(STUB)s' \
+                   '.%(EXT)s'
         return template % {'APP': self.application,
                            'VERSION': self.version,
                            'LOCALE': self.locale,
@@ -719,7 +720,7 @@ class ReleaseCandidateScraper(ReleaseScraper):
                            'BUILD': self.builds[self.build_index],
                            'LOCALE': self.locale,
                            'PLATFORM': self.platform,
-                           'STUB': '-stub' if self.is_stub_installer else '', 
+                           'STUB': '-stub' if self.is_stub_installer else '',
                            'EXT': self.extension}
 
     def download(self):

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -625,11 +625,12 @@ class ReleaseScraper(Scraper):
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary"""
 
-        template = '%(APP)s-%(VERSION)s.%(LOCALE)s.%(PLATFORM)s.%(EXT)s'
+        template = '%(APP)s-%(VERSION)s.%(LOCALE)s.%(PLATFORM)s%(STUB)s.%(EXT)s'
         return template % {'APP': self.application,
                            'VERSION': self.version,
                            'LOCALE': self.locale,
                            'PLATFORM': self.platform,
+                           'STUB': '-stub' if self.is_stub_installer else '',
                            'EXT': self.extension}
 
 
@@ -712,12 +713,13 @@ class ReleaseCandidateScraper(ReleaseScraper):
         """Return the proposed filename with extension for the binary"""
 
         template = '%(APP)s-%(VERSION)s-%(BUILD)s.%(LOCALE)s.' \
-                   '%(PLATFORM)s.%(EXT)s'
+                   '%(PLATFORM)s%(STUB)s.%(EXT)s'
         return template % {'APP': self.application,
                            'VERSION': self.version,
                            'BUILD': self.builds[self.build_index],
                            'LOCALE': self.locale,
                            'PLATFORM': self.platform,
+                           'STUB': '-stub' if self.is_stub_installer else '', 
                            'EXT': self.extension}
 
     def download(self):

--- a/tests/release_candidate_scraper/test_release_candidate_scraper.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper.py
@@ -68,7 +68,7 @@ firefox_tests = [
               'is_stub_installer': True,
               'platform': 'win32',
               'version': '21.0'},
-     'target': 'firefox-21.0-build3.en-US.win32.exe',
+     'target': 'firefox-21.0-build3.en-US.win32-stub.exe',
      'target_url': 'firefox/candidates/21.0-candidates/build3/win32/en-US/Firefox Setup Stub 21.0.exe'},
     # -p win64 -v 37.0b1
     {'args': {'platform': 'win64',

--- a/tests/release_scraper/test_release_scraper.py
+++ b/tests/release_scraper/test_release_scraper.py
@@ -60,7 +60,7 @@ firefox_tests = [
               'platform': 'win32',
               'is_stub_installer': True,
               'version': 'latest'},
-     'target': 'firefox-latest.en-US.win32.exe',
+     'target': 'firefox-latest.en-US.win32-stub.exe',
      'target_url': 'firefox/releases/latest/win32/en-US/Firefox Setup Stub 23.0.1.exe'},
     # -a firefox -p win32 -v 21.0
     {'args': {'application': 'firefox',


### PR DESCRIPTION
This PR addresses issue #167 

I have checked the builds that really have this bug and it turned out to be `release` and `releasecandidate`.

Daily already had it implemented and for tinderbox and try builds, I did not find a stub installer... So I left it out.

In fact, I noticed for tinderbox that we have a potential implementation for stub downloads, however, if they do not exist, we may be able to remove the option...