### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/mozilla/mozdownload.png?label=ready&title=Ready)](https://waffle.io/mozilla/mozdownload)
 # mozdownload
 
 [![Latest Version](https://pypip.in/version/mozdownload/badge.png)](https://pypi.python.org/pypi/mozdownload/)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/mozilla/mozdownload

This was requested by a real person (user whimboo) on waffle.io, we're not trying to spam you.