### PR TITLE
Add scraper.cli to __init__.py

### DIFF
--- a/mozdownload/__init__.py
+++ b/mozdownload/__init__.py
@@ -9,6 +9,7 @@ from .scraper import (Scraper,
                       ReleaseCandidateScraper,
                       TinderboxScraper,
                       TryScraper,
+                      cli,
                       )
 
 __all__ = [Scraper,
@@ -18,4 +19,5 @@ __all__ = [Scraper,
            ReleaseCandidateScraper,
            TinderboxScraper,
            TryScraper,
+           cli,
            ]

--- a/tests/manifest.ini
+++ b/tests/manifest.ini
@@ -6,3 +6,4 @@
 [include:release_scraper/manifest.ini]
 [include:tinderbox_scraper/manifest.ini]
 [include:try_scraper/manifest.ini]
+[test_cli.py]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,12 @@
+import subprocess
+import unittest
+
+from mozdownload import scraper
+
+class TestCLI(unittest.TestCase):
+    """Tests for the cli() function in scraper.py"""
+
+    def test_cli_executes(self):
+        """Test that cli will start and print usage message"""
+        output = subprocess.check_output(['mozdownload'])
+        self.assertTrue(scraper.__doc__ in output)


### PR DESCRIPTION
This fixes what appears to be the accidental removal of scraper.cli from the module __init__.py which prevents calling the module directly to perform downloads. This also adds a test to ensure that mozdownload is callable from the shell.