### PR TITLE
Check that requests exception has a response (#314)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -135,11 +135,8 @@ class Scraper(object):
                                  requests.exceptions.RequestException))
         try:
             self._retry(func, **retry_kwargs)
-        except requests.exceptions.RequestException as exc:
-            # NB: The requests Response object overrides the bool operator to
-            #     return False if there was an HTTP exception, so we need to
-            #     test for None explicitly.
-            if exc.response is not None and exc.response.status_code == 404:
+        except requests.exceptions.HTTPError as exc:
+            if exc.response.status_code == 404:
                 raise errors.NotFoundError(err_message, exc.response.url)
             else:
                 raise

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -139,7 +139,7 @@ class Scraper(object):
             # NB: The requests Response object overrides the bool operator to
             #     return False if there was an HTTP exception, so we need to
             #     test for None explicitly.
-            if exc.response != None and exc.response.status_code == 404:
+            if exc.response is not None and exc.response.status_code == 404:
                 raise errors.NotFoundError(err_message, exc.response.url)
             else:
                 raise

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -136,7 +136,10 @@ class Scraper(object):
         try:
             self._retry(func, **retry_kwargs)
         except requests.exceptions.RequestException as exc:
-            if exc.response.status_code == 404:
+            # NB: The requests Response object overrides the bool operator to
+            #     return False if there was an HTTP exception, so we need to
+            #     test for None explicitly.
+            if exc.response != None and exc.response.status_code == 404:
                 raise errors.NotFoundError(err_message, exc.response.url)
             else:
                 raise


### PR DESCRIPTION
It's possible for a RequestException to not have a response,
for example if a connection times out a Response object will
not have been created.

@whimboo Do you mind taking a look?