### PR TITLE
Improve logging and arguments handling (#360)

### DIFF
--- a/mozdownload/__init__.py
+++ b/mozdownload/__init__.py
@@ -2,26 +2,31 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+__version__ = '1.19'
+
 from . import cli
 
 from .factory import FactoryScraper
 
-from .scraper import (Scraper,
-                      DailyScraper,
-                      DirectScraper,
-                      ReleaseScraper,
-                      ReleaseCandidateScraper,
-                      TinderboxScraper,
-                      TryScraper,
-                      )
+from .scraper import (
+    Scraper,
+    DailyScraper,
+    DirectScraper,
+    ReleaseScraper,
+    ReleaseCandidateScraper,
+    TinderboxScraper,
+    TryScraper,
+)
 
-__all__ = [cli,
-           FactoryScraper,
-           Scraper,
-           DailyScraper,
-           DirectScraper,
-           ReleaseScraper,
-           ReleaseCandidateScraper,
-           TinderboxScraper,
-           TryScraper,
-           ]
+__all__ = [
+    __version__,
+    cli,
+    FactoryScraper,
+    Scraper,
+    DailyScraper,
+    DirectScraper,
+    ReleaseScraper,
+    ReleaseCandidateScraper,
+    TinderboxScraper,
+    TryScraper,
+]

--- a/mozdownload/factory.py
+++ b/mozdownload/factory.py
@@ -31,7 +31,7 @@ class FactoryScraper(scraper.Scraper):
         :param extension: File extension of the build (e.g. ".zip").
         :param is_stub_installer: Stub installer (Only applicable to Windows builds).
         :param locale: Locale of the application.
-        :param log_level: Threshold for log output.
+        :param logger: Logger instance to use.
         :param password: Password for basic HTTP authentication.
         :param platform: Platform of the application
         :param retry_attempts: Number of times the download will be attempted
@@ -73,7 +73,7 @@ class FactoryScraper(scraper.Scraper):
                             'extension': kwargs.get('extension'),
                             'is_stub_installer': kwargs.get('is_stub_installer'),
                             'locale': kwargs.get('locale'),
-                            'log_level': kwargs.get('log_level', 'INFO'),
+                            'logger': kwargs.get('logger', None),
                             'password': kwargs.get('password'),
                             'platform': kwargs.get('platform'),
                             'retry_attempts': kwargs.get('retry_attempts', 0),

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -72,8 +72,10 @@ class Scraper(object):
                  username=None, password=None,
                  retry_attempts=0, retry_delay=10.,
                  is_stub_installer=False, timeout=None,
-                 log_level='INFO',
+                 logger=None,
                  base_url=BASE_URL):
+
+        self.logger = logger or logging.getLogger(self.__module__)
 
         # Private properties for caching
         self._filename = None
@@ -103,11 +105,6 @@ class Scraper(object):
         # it does not work if we attach it on the session, so we handle
         # it independently.
         self.timeout_network = 60.
-
-        logging.basicConfig(format=' %(levelname)s | %(message)s')
-        self.logger = logging.getLogger(self.__module__)
-        self.logger.setLevel(log_level)
-        logging.getLogger('redo').setLevel(logging.INFO)
 
         # build the base URL
         self.application = application

--- a/mozdownload/treeherder.py
+++ b/mozdownload/treeherder.py
@@ -1,0 +1,68 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+
+from thclient import TreeherderClient
+
+# TODO get logger working for treeherder client
+logger = logging.getLogger(__name__)
+
+PLATFORM_MAP = {
+    'android-api-9': {'build_platform': 'android-2-3-armv7-api9'},
+    'android-api-11': {'build_platform': 'android-4-0-armv7-api11'},
+    'android-x86': {'build_platform': 'android-4-2-x86'},
+    'linux': {'build_platform': 'linux32'},
+    'linux64': {'build_platform': 'linux64'},
+    'mac': {'build_os': 'mac', 'build_architecture': 'x86_64'},
+    'mac64': {'build_os': 'mac', 'build_architecture': 'x86_64'},
+    'win32': {'build_os': 'win', 'build_architecture': 'x86'},
+    'win64': {'build_os': 'win', 'build_architecture': 'x86_64'},
+}
+
+
+def get_builds_from_revision(application, branch, revision, platform, job_type_name,
+                             debug_build=False):
+    """Retrieve builds from a given revision with the help of Treeherder."""
+    logger.info('Querying Treeherder to retrieve the list of builds for revision: %s' % revision)
+
+    builds = set()
+
+    try:
+        client = TreeherderClient(protocol='https', host='treeherder.mozilla.org')
+
+        # Retrieve the option hash to filter for type of build (opt, and debug for now)
+        option_hash = None
+        for key, values in client.get_option_collection_hash().iteritems():
+            for value in values:
+                if value['name'] == ('debug' if debug_build else 'opt'):
+                    option_hash = key
+                    break
+            if option_hash:
+                break
+
+        resultsets = client.get_resultsets(branch, revision=revision)
+
+        # Set filters to speed-up querying jobs
+        kwargs = {
+            'result': 'success',
+            'option_collection_hash': option_hash,
+            'job_type_name': job_type_name,
+            'exclusion_profile': False,
+        }
+        kwargs.update(PLATFORM_MAP.get(platform, platform))
+
+        for resultset in resultsets:
+            kwargs.update({'result_set_id': resultset['id']})
+            jobs = client.get_jobs(branch, **kwargs)
+            for job in jobs:
+                log_urls = client.get_job_log_url(branch, job_id=job['id'])
+                for log_url in log_urls:
+                    if application in log_url['url']:
+                        builds.update([log_url['url'].rsplit('/', 2)[1]])
+
+    except Exception:
+        logger.exception('Failure occurred when querying Treeherder for builds')
+
+    return list(builds)

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,22 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 import os
+import re
+
 from setuptools import setup
 
-try:
-    here = os.path.dirname(os.path.abspath(__file__))
-    description = file(os.path.join(here, 'README.md')).read()
-except (OSError, IOError):
-    description = None
+THIS_DIR = os.path.dirname(os.path.realpath(__name__))
 
-version = '1.19'
+
+def read(*parts):
+    with open(os.path.join(THIS_DIR, *parts)) as f:
+        return f.read()
+
+
+def get_version():
+    return re.findall("__version__ = '([\d\.]+)'",
+                      read('mozdownload', '__init__.py'), re.M)[0]
 
 deps = ['mozinfo >= 0.7',
         'progressbar == 2.2',
@@ -23,10 +28,10 @@ deps = ['mozinfo >= 0.7',
         ]
 
 setup(name='mozdownload',
-      version=version,
+      version=get_version(),
       description='Script to download builds for Firefox and Thunderbird '
                   'from the Mozilla server.',
-      long_description=description,
+      long_description=read('README.md'),
       # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[],
       keywords='mozilla',

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -36,7 +36,7 @@ class TestBaseScraper(mhttpd.MozHttpdBaseTest):
         test_url = urljoin(self.wdir, filename)
         scraper = mozdownload.DirectScraper(url=test_url,
                                             destination=self.temp_dir,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     filename)))
@@ -51,7 +51,7 @@ class TestBaseScraper(mhttpd.MozHttpdBaseTest):
         test_url1 = urljoin(self.wdir, 'does_not_exist.html')
         scraper1 = mozdownload.DirectScraper(url=test_url1,
                                              destination=self.temp_dir,
-                                             log_level='ERROR')
+                                             logger=self.logger)
         self.assertRaises(requests.exceptions.RequestException,
                           scraper1.download)
 
@@ -61,13 +61,13 @@ class TestBaseScraper(mhttpd.MozHttpdBaseTest):
                                              destination=self.temp_dir,
                                              retry_attempts=3,
                                              retry_delay=1.0,
-                                             log_level='ERROR')
+                                             logger=self.logger)
         self.assertRaises(requests.exceptions.RequestException,
                           scraper2.download)
 
     def test_notimplementedexceptions(self):
         scraper = mozdownload.Scraper(destination=self.temp_dir,
-                                      log_level='ERROR')
+                                      logger=self.logger)
         for attr in ['binary', 'binary_regex', 'path_regex']:
             self.assertRaises(errors.NotImplementedError, getattr,
                               scraper, attr)
@@ -83,13 +83,13 @@ class TestBaseScraper(mhttpd.MozHttpdBaseTest):
         # test with invalid authentication
         scraper = mozdownload.DirectScraper(destination=self.temp_dir,
                                             url=basic_auth_url,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         self.assertRaises(requests.exceptions.HTTPError, scraper.download)
 
         # testing with valid authentication
         scraper = mozdownload.DirectScraper(destination=self.temp_dir,
                                             url=basic_auth_url,
-                                            log_level='ERROR',
+                                            logger=self.logger,
                                             username=username,
                                             password=password)
         scraper.download()
@@ -103,7 +103,7 @@ class TestBaseScraper(mhttpd.MozHttpdBaseTest):
         # requires optional authentication with no data specified
         scraper = mozdownload.DirectScraper(destination=self.temp_dir,
                                             url=optional_auth_url,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     'webqa-ci.mozilla.com')))
@@ -117,34 +117,34 @@ class TestBaseScraper(mhttpd.MozHttpdBaseTest):
         # destination is directory
         scraper = mozdownload.DirectScraper(url=test_url,
                                             destination=self.temp_dir,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         self.assertEqual(scraper.filename, os.path.join(self.temp_dir, filename))
 
         # destination has directory path with filename
         destination = os.path.join(self.temp_dir, filename)
         scraper = mozdownload.DirectScraper(url=test_url,
                                             destination=destination,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         self.assertEqual(scraper.filename, destination)
 
         # destination only has filename
         scraper = mozdownload.DirectScraper(url=test_url,
                                             destination=filename,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         self.assertEqual(scraper.filename, os.path.abspath(filename))
 
         # destination directory does not exist
         destination = os.path.join(self.temp_dir, 'temp_folder', filename)
         scraper = mozdownload.DirectScraper(url=test_url,
                                             destination=destination,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         self.assertEqual(scraper.destination, destination)
 
         # ensure that multiple non existing directories are created
         destination = os.path.join(self.temp_dir, 'tmp1', 'tmp2', filename)
         scraper = mozdownload.DirectScraper(url=test_url,
                                             destination=destination,
-                                            log_level='ERROR')
+                                            logger=self.logger)
         self.assertEqual(scraper.destination, destination)
 
 

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -1,7 +1,7 @@
 import subprocess
 import unittest
 
-from mozdownload import cli
+from mozdownload import __version__, cli
 
 
 class TestCLIOutput(unittest.TestCase):
@@ -9,5 +9,5 @@ class TestCLIOutput(unittest.TestCase):
 
     def test_cli_executes(self):
         """Test that cli will start and print usage message"""
-        output = subprocess.check_output(['mozdownload'])
-        self.assertTrue(cli.__doc__ in output)
+        output = subprocess.check_output(['mozdownload', '--help'])
+        self.assertTrue(cli.__doc__.format(__version__) in output)

--- a/tests/daily_scraper/test_daily_indices.py
+++ b/tests/daily_scraper/test_daily_indices.py
@@ -49,7 +49,7 @@ class TestDailyScraperIndices(mhttpd.MozHttpdBaseTest):
         for entry in test_params:
             scraper = DailyScraper(destination=self.temp_dir,
                                    base_url=self.wdir,
-                                   log_level='ERROR',
+                                   logger=self.logger,
                                    **entry['args'])
             self.assertEqual(scraper.build_index, entry['build_index'])
             self.assertEqual(scraper.builds, entry['builds'])

--- a/tests/daily_scraper/test_daily_scraper.py
+++ b/tests/daily_scraper/test_daily_scraper.py
@@ -348,7 +348,7 @@ class TestDailyScraper(mhttpd.MozHttpdBaseTest):
         for entry in tests:
             scraper = DailyScraper(destination=self.temp_dir,
                                    base_url=self.wdir,
-                                   log_level='ERROR',
+                                   logger=self.logger,
                                    **entry['args'])
 
             expected_target = os.path.join(self.temp_dir, entry['filename'])

--- a/tests/daily_scraper/test_invalid_branch.py
+++ b/tests/daily_scraper/test_invalid_branch.py
@@ -34,7 +34,7 @@ class TestDailyScraperInvalidBranch(mhttpd.MozHttpdBaseTest):
             self.assertRaises(errors.NotFoundError, DailyScraper,
                               destination=self.temp_dir,
                               base_url=self.wdir,
-                              log_level='ERROR',
+                              logger=self.logger,
                               **entry['args'])
 
 

--- a/tests/daily_scraper/test_invalid_date.py
+++ b/tests/daily_scraper/test_invalid_date.py
@@ -44,7 +44,7 @@ class TestDailyScraperInvalidParameters(mhttpd.MozHttpdBaseTest):
             self.assertRaises(ValueError, DailyScraper,
                               destination=self.temp_dir,
                               base_url=self.wdir,
-                              log_level='ERROR',
+                              logger=self.logger,
                               **entry['args'])
 
 

--- a/tests/direct_scraper/test_direct_scraper.py
+++ b/tests/direct_scraper/test_direct_scraper.py
@@ -21,7 +21,7 @@ class TestDirectScraper(mhttpd.MozHttpdBaseTest):
         test_url = urljoin(self.wdir, filename)
         scraper = DirectScraper(url=test_url,
                                 destination=self.temp_dir,
-                                log_level='ERROR')
+                                logger=self.logger)
         self.assertEqual(scraper.url, test_url)
         self.assertEqual(scraper.filename,
                          os.path.join(self.temp_dir, filename))

--- a/tests/factory/test_factory_invalid_options.py
+++ b/tests/factory/test_factory_invalid_options.py
@@ -97,7 +97,7 @@ class TestFactoryMissingMandatoryOptions(mhttpd.MozHttpdBaseTest):
                           scraper_type='release',
                           destination=self.temp_dir,
                           base_url=self.wdir,
-                          log_level='ERROR')
+                          logger=self.logger)
 
     def test_candidate_without_version(self):
         """Test that missing mandatory options for candidate builds raise an exception"""
@@ -105,7 +105,7 @@ class TestFactoryMissingMandatoryOptions(mhttpd.MozHttpdBaseTest):
                           scraper_type='release',
                           destination=self.temp_dir,
                           base_url=self.wdir,
-                          log_level='ERROR')
+                          logger=self.logger)
 
 
 class TestFactoryUnusedOptions(mhttpd.MozHttpdBaseTest):
@@ -138,7 +138,7 @@ class TestFactoryUnusedOptions(mhttpd.MozHttpdBaseTest):
         scraper = FactoryScraper(scraper_type='direct',
                                  url=test_url,
                                  destination=self.temp_dir,
-                                 log_level='ERROR',
+                                 logger=self.logger,
 
                                  platform='win32',
                                  branch='mozilla-central',

--- a/tests/release_candidate_scraper/test_release_candidate_scraper.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper.py
@@ -113,7 +113,7 @@ class ReleaseCandidateScraperTest(mhttpd.MozHttpdBaseTest):
         for entry in tests:
             scraper = ReleaseCandidateScraper(destination=self.temp_dir,
                                               base_url=self.wdir,
-                                              log_level='ERROR',
+                                              logger=self.logger,
                                               **entry['args'])
             expected_filename = os.path.join(self.temp_dir, entry['filename'])
             self.assertEqual(scraper.filename, expected_filename)

--- a/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
@@ -53,7 +53,7 @@ class ReleaseCandidateScraperTest_build_indices(mhttpd.MozHttpdBaseTest):
         for entry in test_params:
             scraper = ReleaseCandidateScraper(destination=self.temp_dir,
                                               base_url=self.wdir,
-                                              log_level='ERROR',
+                                              logger=self.logger,
                                               **entry['args'])
             self.assertEqual(scraper.build_index, entry['build_index'])
             self.assertEqual(scraper.build_number, entry['build_number'])

--- a/tests/release_candidate_scraper/test_release_candidate_scraper_latest.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper_latest.py
@@ -197,7 +197,7 @@ class ReleaseCandidateScraperTest(mhttpd.MozHttpdBaseTest):
         for entry in tests:
             scraper = ReleaseCandidateScraper(destination=self.temp_dir,
                                               base_url=self.wdir,
-                                              log_level='ERROR',
+                                              logger=self.logger,
                                               **entry['args'])
             expected_filename = os.path.join(self.temp_dir, entry['filename'])
             self.assertEqual(scraper.filename, expected_filename)

--- a/tests/release_scraper/test_release_scraper.py
+++ b/tests/release_scraper/test_release_scraper.py
@@ -112,7 +112,7 @@ class ReleaseScraperTest(mhttpd.MozHttpdBaseTest):
         for entry in tests:
             scraper = ReleaseScraper(destination=self.temp_dir,
                                      base_url=self.wdir,
-                                     log_level='ERROR',
+                                     logger=self.logger,
                                      **entry['args'])
             expected_filename = os.path.join(self.temp_dir, entry['filename'])
             self.assertEqual(scraper.filename, expected_filename)

--- a/tests/release_scraper/test_release_scraper_latest.py
+++ b/tests/release_scraper/test_release_scraper_latest.py
@@ -198,7 +198,7 @@ class ReleaseScraperTest(mhttpd.MozHttpdBaseTest):
         for entry in tests:
             scraper = ReleaseScraper(destination=self.temp_dir,
                                      base_url=self.wdir,
-                                     log_level='ERROR',
+                                     logger=self.logger,
                                      **entry['args'])
             expected_filename = os.path.join(self.temp_dir, entry['filename'])
             self.assertEqual(scraper.filename, expected_filename)

--- a/tests/remote/test_fennec.py
+++ b/tests/remote/test_fennec.py
@@ -85,7 +85,7 @@ class FennecRemoteTests(unittest.TestCase):
     def test_daily_scraper(self):
         for test in tests_daily_scraper:
             mozdownload.DailyScraper(destination=self.temp_dir,
-                                     log_level='ERROR',
+                                     logger=self.logger,
                                      **test['args'])
 
 

--- a/tests/remote/test_firefox.py
+++ b/tests/remote/test_firefox.py
@@ -223,7 +223,7 @@ class FirefoxRemoteTests(unittest.TestCase):
     def test_release_scraper(self):
         for test in tests_release_scraper:
             scraper = mozdownload.ReleaseScraper(destination=self.temp_dir,
-                                                 log_level='ERROR',
+                                                 logger=self.logger,
                                                  **test['args'])
             if test.get('url'):
                 self.assertEqual(urllib.unquote(scraper.url),
@@ -232,7 +232,7 @@ class FirefoxRemoteTests(unittest.TestCase):
     def test_candidate_scraper(self):
         for test in tests_candidate_scraper:
             scraper = mozdownload.ReleaseCandidateScraper(destination=self.temp_dir,
-                                                          log_level='ERROR',
+                                                          logger=self.logger,
                                                           **test['args'])
             if test.get('url'):
                 self.assertEqual(urllib.unquote(scraper.url),
@@ -241,13 +241,13 @@ class FirefoxRemoteTests(unittest.TestCase):
     def test_daily_scraper(self):
         for test in tests_daily_scraper:
             mozdownload.DailyScraper(destination=self.temp_dir,
-                                     log_level='ERROR',
+                                     logger=self.logger,
                                      **test['args'])
 
     def test_tinderbox_scraper(self):
         for test in tests_tinderbox_scraper:
             mozdownload.TinderboxScraper(destination=self.temp_dir,
-                                         log_level='ERROR',
+                                         logger=self.logger,
                                          **test['args'])
 
     @unittest.skip('Not testable as long as we cannot grab a latest build')

--- a/tests/remote/test_thunderbird.py
+++ b/tests/remote/test_thunderbird.py
@@ -228,7 +228,7 @@ class ThunderbirdRemoteTests(unittest.TestCase):
     def test_release_scraper(self):
         for test in tests_release_scraper:
             scraper = mozdownload.ReleaseScraper(destination=self.temp_dir,
-                                                 log_level='ERROR',
+                                                 logger=self.logger,
                                                  **test['args'])
             if test.get('url'):
                 self.assertEqual(urllib.unquote(scraper.url),
@@ -237,7 +237,7 @@ class ThunderbirdRemoteTests(unittest.TestCase):
     def test_candidate_scraper(self):
         for test in tests_candidate_scraper:
             scraper = mozdownload.ReleaseCandidateScraper(destination=self.temp_dir,
-                                                          log_level='ERROR',
+                                                          logger=self.logger,
                                                           **test['args'])
             if test.get('url'):
                 self.assertEqual(urllib.unquote(scraper.url),
@@ -247,13 +247,13 @@ class ThunderbirdRemoteTests(unittest.TestCase):
     def test_daily_scraper(self):
         for test in tests_daily_scraper:
             mozdownload.DailyScraper(destination=self.temp_dir,
-                                     log_level='ERROR',
+                                     logger=self.logger,
                                      **test['args'])
 
     def test_tinderbox_scraper(self):
         for test in tests_tinderbox_scraper:
             mozdownload.TinderboxScraper(destination=self.temp_dir,
-                                         log_level='ERROR',
+                                         logger=self.logger,
                                          **test['args'])
 
 

--- a/tests/tinderbox_scraper/test_invalid_date.py
+++ b/tests/tinderbox_scraper/test_invalid_date.py
@@ -48,7 +48,7 @@ class TestTinderboxScraperInvalidParameters(mhttpd.MozHttpdBaseTest):
             self.assertRaises(ValueError, TinderboxScraper,
                               destination=self.temp_dir,
                               base_url=self.wdir,
-                              log_level='ERROR',
+                              logger=self.logger,
                               **entry['args'])
 
 

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -266,7 +266,7 @@ class TinderboxScraperTest(mhttpd.MozHttpdBaseTest):
         for entry in tests:
             scraper = TinderboxScraper(destination=self.temp_dir,
                                        base_url=self.wdir,
-                                       log_level='ERROR',
+                                       logger=self.logger,
                                        **entry['args'])
             expected_filename = os.path.join(self.temp_dir, entry['filename'])
             self.assertEqual(scraper.filename, expected_filename)

--- a/tests/try_scraper/test_invalid_changeset.py
+++ b/tests/try_scraper/test_invalid_changeset.py
@@ -32,7 +32,7 @@ class TestTryScraperInvalidParameters(mhttpd.MozHttpdBaseTest):
             self.assertRaises(errors.NotFoundError, TryScraper,
                               destination=self.temp_dir,
                               base_url=self.wdir,
-                              log_level='ERROR',
+                              logger=self.logger,
                               **entry['args'])
 
 

--- a/tests/try_scraper/test_try_scraper.py
+++ b/tests/try_scraper/test_try_scraper.py
@@ -64,7 +64,7 @@ class TryScraperTest(mhttpd.MozHttpdBaseTest):
         for entry in tests:
             scraper = TryScraper(destination=self.temp_dir,
                                  base_url=self.wdir,
-                                 log_level='ERROR',
+                                 logger=self.logger,
                                  **entry['args'])
             expected_filename = os.path.join(self.temp_dir, entry['filename'])
             self.assertEqual(scraper.filename, expected_filename)


### PR DESCRIPTION
This will fix issue #360. Please keep in mind that remote fennec tests are currently broken because API level 11 is no longer supported. I will file a separate issue to get this fixed.

@sydvicious can you please review? Please note that I pushed individual commits so it should make it easier for you to go through the code. Thanks!