### PR TITLE
CLI command fails due to broken argv parsing (#378)

### DIFF
--- a/mozdownload/cli.py
+++ b/mozdownload/cli.py
@@ -141,7 +141,7 @@ def parse_arguments(argv):
 
 def cli(argv=None):
     """CLI entry point for mozdownload."""
-    kwargs = parse_arguments(argv or sys.argv)
+    kwargs = parse_arguments(argv or sys.argv[1:])
 
     log_level = kwargs.pop('log_level')
     logging.basicConfig(format='%(levelname)s | %(message)s', level=log_level)

--- a/tests/cli/manifest.ini
+++ b/tests/cli/manifest.ini
@@ -1,2 +1,3 @@
+[test_cli_arguments.py]
 [test_correct_scraper.py]
 [test_output.py]

--- a/tests/cli/test_cli_arguments.py
+++ b/tests/cli/test_cli_arguments.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import subprocess
+import unittest
+
+
+class TestCLIArguments(unittest.TestCase):
+    """Test CLI entry script for arguments."""
+
+    def test_unrecognized_argument(self):
+        try:
+            output = subprocess.check_output(['mozdownload', '--abc'],
+                                             stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            output = e.output
+
+        self.assertRegexpMatches(output, r'mozdownload: error: unrecognized arguments: --abc')


### PR DESCRIPTION
This is the bustage fix for issue #378 and also includes a test so that we can be safe it won't happen again.

@mjzffr or @sydvicious could you please review?