### PR TITLE
Add Appveyor support for running unittests on Windows (#380)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,22 @@
+build: false
+
+environment:
+    PYTHON: "C:\\Python27"
+    TOXENV: "py27"
+
+init:
+    - ECHO %PYTHON%
+    - ECHO %TOXENV%
+    - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+
+install:
+    - python -m pip install --upgrade pip
+    # Latest tox 2.3.x is currently busted:
+    # https://bitbucket.org/hpk42/tox/issues/314/tox-command-busted-on-windows
+    - pip install pylama tox==2.2.0
+
+before_test:
+    - pylama mozdownload
+
+test_script:
+    - tox


### PR DESCRIPTION
This PR will fix issue #380. It's not ready yet for review and might need updates according to appveyor failures.