### PR TITLE
Added date to tinderbox filename when human readable date supplied (#181)

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -823,16 +823,14 @@ class TinderboxScraper(Scraper):
 
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary."""
-        if not self.timestamp and self.date:
-            date = self.date.strftime('%Y-%m-%d-')
-        else:
-            date = ''
-        # str(...) necessary to create str type else unicode --> test_tinderbox fail
-        return str('%(TIMESTAMP)s%(BRANCH)s%(DEBUG)s-%(NAME)s' % {
-            'TIMESTAMP': self.timestamp + '-' if self.timestamp else str(date),
+        if hasattr(self, 'builds'):
+            self.timestamp = self.builds[self.build_index]
+
+        return '%(TIMESTAMP)s%(BRANCH)s%(DEBUG)s-%(NAME)s' % {
+            'TIMESTAMP': self.timestamp + '-' if self.timestamp else '',
             'BRANCH': self.branch,
             'DEBUG': '-debug' if self.debug_build else '',
-            'NAME': binary})
+            'NAME': binary}
 
     @property
     def build_list_regex(self):

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -800,7 +800,7 @@ class TinderboxScraper(Scraper):
         if not self.locale_build:
             self.builds, self.build_index = self.get_build_info_for_index(
                 self.build_index)
-            # Assigned to provide unique timestamp in filename for each file
+            # Always force a timestamp prefix in the filename
             self.timestamp = self.builds[self.build_index]
 
     @property

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -743,7 +743,6 @@ class TinderboxScraper(Scraper):
         """Create instance of a tinderbox scraper."""
         self.branch = branch
         self.build_number = build_number
-        self.builds = []
         self.debug_build = debug_build
         self.date = date
         self.revision = revision
@@ -824,7 +823,7 @@ class TinderboxScraper(Scraper):
 
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary."""
-        if not self.locale_build:
+        if hasattr(self, 'builds'):
             self.timestamp = self.builds[self.build_index]
 
         return '%(TIMESTAMP)s%(BRANCH)s%(DEBUG)s-%(NAME)s' % {

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -800,6 +800,7 @@ class TinderboxScraper(Scraper):
         if not self.locale_build:
             self.builds, self.build_index = self.get_build_info_for_index(
                 self.build_index)
+            # Assigned to provide unique timestamp in filename for each file
             self.timestamp = self.builds[self.build_index]
 
     @property

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -800,6 +800,7 @@ class TinderboxScraper(Scraper):
         if not self.locale_build:
             self.builds, self.build_index = self.get_build_info_for_index(
                 self.build_index)
+            self.timestamp = self.builds[self.build_index]
 
     @property
     def binary_regex(self):
@@ -823,8 +824,6 @@ class TinderboxScraper(Scraper):
 
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary."""
-        if hasattr(self, 'builds'):
-            self.timestamp = self.builds[self.build_index]
 
         return '%(TIMESTAMP)s%(BRANCH)s%(DEBUG)s-%(NAME)s' % {
             'TIMESTAMP': self.timestamp + '-' if self.timestamp else '',

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -823,11 +823,16 @@ class TinderboxScraper(Scraper):
 
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary."""
-        return '%(TIMESTAMP)s%(BRANCH)s%(DEBUG)s-%(NAME)s' % {
-            'TIMESTAMP': self.timestamp + '-' if self.timestamp else '',
+        if not self.timestamp and self.date:
+            date = self.date.strftime('%Y-%m-%d-')
+        else:
+            date = ''
+        # str(...) necessary to create str type else unicode --> test_tinderbox fail
+        return str('%(TIMESTAMP)s%(BRANCH)s%(DEBUG)s-%(NAME)s' % {
+            'TIMESTAMP': self.timestamp + '-' if self.timestamp else str(date),
             'BRANCH': self.branch,
             'DEBUG': '-debug' if self.debug_build else '',
-            'NAME': binary}
+            'NAME': binary})
 
     @property
     def build_list_regex(self):

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -743,6 +743,7 @@ class TinderboxScraper(Scraper):
         """Create instance of a tinderbox scraper."""
         self.branch = branch
         self.build_number = build_number
+        self.builds = []
         self.debug_build = debug_build
         self.date = date
         self.revision = revision
@@ -823,7 +824,7 @@ class TinderboxScraper(Scraper):
 
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary."""
-        if hasattr(self, 'builds'):
+        if not self.locale_build:
             self.timestamp = self.builds[self.build_index]
 
         return '%(TIMESTAMP)s%(BRANCH)s%(DEBUG)s-%(NAME)s' % {

--- a/tests/cli/test_correct_scraper.py
+++ b/tests/cli/test_correct_scraper.py
@@ -31,7 +31,7 @@ tests = {
 
     'tinderbox': {
         'args': ['-t', 'tinderbox', '-p', 'win32'],
-        'fname': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+        'fname': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
     },
 
     'try': {

--- a/tests/factory/test_factory_invalid_options.py
+++ b/tests/factory/test_factory_invalid_options.py
@@ -62,7 +62,7 @@ tests = [
     # TinderboxScraper
     {
         'scraper_type': 'tinderbox',
-        'fname': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+        'fname': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
         'kwargs': {
             'platform': 'win32',
 

--- a/tests/factory/test_factory_scraper.py
+++ b/tests/factory/test_factory_scraper.py
@@ -41,7 +41,7 @@ tests = [
     # TinderboxScraper
     {
         'scraper_type': 'tinderbox',
-        'fname': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+        'fname': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
         'kwargs': {
             'platform': 'win32',
         },

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -17,19 +17,19 @@ import mozhttpd_base_test as mhttpd
 firefox_tests = [
     # -p win32
     {'args': {'platform': 'win32'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -p win32 --branch=mozilla-central
     {'args': {'branch': 'mozilla-central',
               'platform': 'win32'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win32
     {'args': {'application': 'firefox',
               'platform': 'win32'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win32 --date 1374573725 --stub (old format)
@@ -51,27 +51,27 @@ firefox_tests = [
     # -a firefox -p linux --branch=mozilla-central
     {'args': {'branch': 'mozilla-central',
               'platform': 'linux'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.linux-i686.tar.bz2',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.linux-i686.tar.bz2',
      'url': 'firefox/tinderbox-builds/mozilla-central-linux/'
             '1374583608/firefox-25.0a1.en-US.linux-i686.tar.bz2'},
     # -a firefox -p linux64 --branch=mozilla-central
     {'args': {'branch': 'mozilla-central',
               'platform': 'linux64'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.linux-x86_64.tar.bz2',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.linux-x86_64.tar.bz2',
      'url': 'firefox/tinderbox-builds/mozilla-central-linux64/'
             '1374583608/firefox-25.0a1.en-US.linux-x86_64.tar.bz2'},
     # -a firefox -p win32 --branch=mozilla-central
     {'args': {'application': 'firefox',
               'branch': 'mozilla-central',
               'platform': 'win32'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win64 --branch=mozilla-central
     {'args': {'application': 'firefox',
               'branch': 'mozilla-central',
               'platform': 'win64'},
-     'filename': 'mozilla-central-firefox-38.0a1.en-US.win64.installer.exe',
+     'filename': '1423517445-mozilla-central-firefox-38.0a1.en-US.win64.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win64/'
             '1423517445/firefox-38.0a1.en-US.win64.installer.exe'},
     # -a firefox -p win64 --branch=mozilla-central --date=2013-07-23 (old filename format)
@@ -79,14 +79,14 @@ firefox_tests = [
               'branch': 'mozilla-central',
               'platform': 'win64',
               'date': '2013-07-23'},
-     'filename': '2013-07-23-mozilla-central-firefox-25.0a1.en-US.win64-x86_64.installer.exe',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.win64-x86_64.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win64/'
             '1374583608/firefox-25.0a1.en-US.win64-x86_64.installer.exe'},
     # -a firefox -p mac64 --branch=mozilla-central
     {'args': {'application': 'firefox',
               'branch': 'mozilla-central',
               'platform': 'mac64'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.mac.dmg',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.mac.dmg',
      'url': 'firefox/tinderbox-builds/mozilla-central-macosx64/'
             '1374583608/firefox-25.0a1.en-US.mac.dmg'},
     # -a firefox -p win32 --branch=mozilla-central --debug-build
@@ -94,7 +94,7 @@ firefox_tests = [
               'branch': 'mozilla-central',
               'debug_build': True,
               'platform': 'win32'},
-     'filename': 'mozilla-central-debug-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374583608-mozilla-central-debug-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32-debug/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win32 --branch=mozilla-central -l de
@@ -118,7 +118,7 @@ firefox_tests = [
               'branch': 'mozilla-central',
               'date': '2013-07-23',
               'platform': 'win32'},
-     'filename': '2013-07-23-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win32 --branch=mozilla-central --date=2013-07-23 --build-number=1
@@ -127,7 +127,7 @@ firefox_tests = [
               'build_number': '1',
               'date': '2013-07-23',
               'platform': 'win32'},
-     'filename': '2013-07-23-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374568307-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374568307/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win32 --branch=mozilla-central --date=1374573725
@@ -142,7 +142,7 @@ firefox_tests = [
     {'args': {'application': 'firefox',
               'branch': 'mozilla-inbound',
               'platform': 'win32'},
-     'filename': 'mozilla-inbound-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '1374583608-mozilla-inbound-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-inbound-win32/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -t tinderbox -p linux --branch=mozilla-central --extension=txt
@@ -150,21 +150,21 @@ firefox_tests = [
               'branch': 'mozilla-central',
               'extension': 'txt',
               'platform': 'linux'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.linux-i686.txt',
+     'filename': '1374583608-mozilla-central-firefox-25.0a1.en-US.linux-i686.txt',
      'url': 'firefox/tinderbox-builds/mozilla-central-linux/'
             '1374583608/firefox-25.0a1.en-US.linux-i686.txt'},
     # -a firefox -t tinderbox -p win32 --extension=txt
     {'args': {'application': 'firefox',
               'extension': 'txt',
               'platform': 'win32'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win32.txt',
+     'filename': '1374568307-mozilla-central-firefox-25.0a1.en-US.win32.txt',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374568307/firefox-25.0a1.en-US.win32.txt'},
     # -a firefox -t tinderbox -p mac --extension=txt
     {'args': {'application': 'firefox',
               'extension': 'txt',
               'platform': 'mac'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.mac.txt',
+     'filename': '1374568307-mozilla-central-firefox-25.0a1.en-US.mac.txt',
      'url': 'firefox/tinderbox-builds/mozilla-central-macosx64/'
             '1374568307/firefox-25.0a1.en-US.mac.txt'},
 ]
@@ -174,35 +174,35 @@ thunderbird_tests = [
     {'args': {'application': 'thunderbird',
               'branch': 'comm-central',
               'platform': 'linux'},
-     'filename': 'comm-central-thunderbird-27.0a1.en-US.linux-i686.tar.bz2',
+     'filename': '1380362686-comm-central-thunderbird-27.0a1.en-US.linux-i686.tar.bz2',
      'url': 'thunderbird/tinderbox-builds/comm-central-linux/'
             '1380362686/thunderbird-27.0a1.en-US.linux-i686.tar.bz2'},
     # -a thunderbird -p linux64 --branch=comm-central
     {'args': {'application': 'thunderbird',
               'branch': 'comm-central',
               'platform': 'linux64'},
-     'filename': 'comm-central-thunderbird-27.0a1.en-US.linux-x86_64.tar.bz2',
+     'filename': '1380362686-comm-central-thunderbird-27.0a1.en-US.linux-x86_64.tar.bz2',
      'url': 'thunderbird/tinderbox-builds/comm-central-linux64/'
             '1380362686/thunderbird-27.0a1.en-US.linux-x86_64.tar.bz2'},
     # -a thunderbird -p mac64 --branch=comm-central
     {'args': {'application': 'thunderbird',
               'branch': 'comm-central',
               'platform': 'mac64'},
-     'filename': 'comm-central-thunderbird-27.0a1.en-US.mac.dmg',
+     'filename': '1380362686-comm-central-thunderbird-27.0a1.en-US.mac.dmg',
      'url': 'thunderbird/tinderbox-builds/comm-central-macosx64/'
             '1380362686/thunderbird-27.0a1.en-US.mac.dmg'},
     # -a thunderbird -p win32 --branch=comm-central
     {'args': {'application': 'thunderbird',
               'branch': 'comm-central',
               'platform': 'win32'},
-     'filename': 'comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
+     'filename': '1380362686-comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-central-win32/'
             '1380362686/thunderbird-27.0a1.en-US.win32.installer.exe'},
     # -a thunderbird -p win64 --branch=comm-central
     {'args': {'application': 'thunderbird',
               'branch': 'comm-central',
               'platform': 'win64'},
-     'filename': 'comm-central-thunderbird-27.0a1.en-US.win64-x86_64.installer.exe',
+     'filename': '1380362686-comm-central-thunderbird-27.0a1.en-US.win64-x86_64.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-central-win64/'
             '1380362686/thunderbird-27.0a1.en-US.win64-x86_64.installer.exe'},
     # -a thunderbird -p win32 --branch=comm-central --debug-build
@@ -210,7 +210,7 @@ thunderbird_tests = [
               'branch': 'comm-central',
               'debug_build': True,
               'platform': 'win32'},
-     'filename': 'comm-central-debug-thunderbird-27.0a1.en-US.win32.installer.exe',
+     'filename': '1380362686-comm-central-debug-thunderbird-27.0a1.en-US.win32.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-central-win32-debug/'
             '1380362686/thunderbird-27.0a1.en-US.win32.installer.exe'},
     # -a thunderbird -p win32 --branch=comm-central -l de
@@ -234,7 +234,7 @@ thunderbird_tests = [
               'branch': 'comm-central',
               'date': '2013-09-28',
               'platform': 'win32'},
-     'filename': '2013-09-28-comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
+     'filename': '1380362686-comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-central-win32/'
             '1380362686/thunderbird-27.0a1.en-US.win32.installer.exe'},
     # -a thunderbird -p win32 --branch=comm-central --date=2013-07-24 --build-number=1
@@ -243,7 +243,7 @@ thunderbird_tests = [
               'build_number': '1',
               'date': '2013-09-28',
               'platform': 'win32'},
-     'filename': '2013-09-28-comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
+     'filename': '1380362527-comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-central-win32/'
             '1380362527/thunderbird-27.0a1.en-US.win32.installer.exe'},
     # -a thunderbird -p win32 --branch=comm-central --date=1380362527
@@ -258,7 +258,7 @@ thunderbird_tests = [
     {'args': {'application': 'thunderbird',
               'branch': 'comm-aurora',
               'platform': 'win32'},
-     'filename': 'comm-aurora-thunderbird-27.0a1.en-US.win32.installer.exe',
+     'filename': '1380362686-comm-aurora-thunderbird-27.0a1.en-US.win32.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-aurora-win32/'
             '1380362686/thunderbird-27.0a1.en-US.win32.installer.exe'}
 ]

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -79,7 +79,7 @@ firefox_tests = [
               'branch': 'mozilla-central',
               'platform': 'win64',
               'date': '2013-07-23'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win64-x86_64.installer.exe',
+     'filename': '2013-07-23-mozilla-central-firefox-25.0a1.en-US.win64-x86_64.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win64/'
             '1374583608/firefox-25.0a1.en-US.win64-x86_64.installer.exe'},
     # -a firefox -p mac64 --branch=mozilla-central
@@ -118,7 +118,7 @@ firefox_tests = [
               'branch': 'mozilla-central',
               'date': '2013-07-23',
               'platform': 'win32'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '2013-07-23-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374583608/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win32 --branch=mozilla-central --date=2013-07-23 --build-number=1
@@ -127,7 +127,7 @@ firefox_tests = [
               'build_number': '1',
               'date': '2013-07-23',
               'platform': 'win32'},
-     'filename': 'mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
+     'filename': '2013-07-23-mozilla-central-firefox-25.0a1.en-US.win32.installer.exe',
      'url': 'firefox/tinderbox-builds/mozilla-central-win32/'
             '1374568307/firefox-25.0a1.en-US.win32.installer.exe'},
     # -a firefox -p win32 --branch=mozilla-central --date=1374573725
@@ -234,7 +234,7 @@ thunderbird_tests = [
               'branch': 'comm-central',
               'date': '2013-09-28',
               'platform': 'win32'},
-     'filename': 'comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
+     'filename': '2013-09-28-comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-central-win32/'
             '1380362686/thunderbird-27.0a1.en-US.win32.installer.exe'},
     # -a thunderbird -p win32 --branch=comm-central --date=2013-07-24 --build-number=1
@@ -243,7 +243,7 @@ thunderbird_tests = [
               'build_number': '1',
               'date': '2013-09-28',
               'platform': 'win32'},
-     'filename': 'comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
+     'filename': '2013-09-28-comm-central-thunderbird-27.0a1.en-US.win32.installer.exe',
      'url': 'thunderbird/tinderbox-builds/comm-central-win32/'
             '1380362527/thunderbird-27.0a1.en-US.win32.installer.exe'},
     # -a thunderbird -p win32 --branch=comm-central --date=1380362527


### PR DESCRIPTION
The filename for human-readable code is now prepended by the date format `YYYY-MM-DD-`

If you decide you want a different format or a universal format (e.g. all timestamps) then please let me know.

Closes #181 