### PR TITLE
Fix remote tests due to non-existent candidate builds (#413)

### DIFF
--- a/tests/remote/test_firefox.py
+++ b/tests/remote/test_firefox.py
@@ -68,41 +68,41 @@ tests_release_scraper = [
 ]
 
 tests_candidate_scraper = [
-    # -p win32 -v 31.8.0esr --build-number=1
+    # -p win32 -v 45.4.0esr --build-number=1
     {'args': {'application': 'firefox',
               'platform': 'win32',
-              'version': '31.8.0esr',
+              'version': '45.4.0esr',
               'build_number': 1},
-     'url': 'firefox/candidates/31.8.0esr-candidates/build1/win32/en-US/Firefox Setup 31.8.0esr.exe'},
+     'url': 'firefox/candidates/45.4.0esr-candidates/build1/win32/en-US/Firefox Setup 45.4.0esr.exe'},
 
-    # -a firefox -p linux -v 31.8.0esr --build-number=1
+    # -a firefox -p linux -v 45.4.0esr --build-number=1
     {'args': {'application': 'firefox',
               'platform': 'linux',
-              'version': '31.8.0esr',
+              'version': '45.4.0esr',
               'build_number': 1},
-     'url': 'firefox/candidates/31.8.0esr-candidates/build1/linux-i686/en-US/firefox-31.8.0esr.tar.bz2'},
+     'url': 'firefox/candidates/45.4.0esr-candidates/build1/linux-i686/en-US/firefox-45.4.0esr.tar.bz2'},
 
-    # -a firefox -p linux64 -v 31.8.0esr --build-number=1
+    # -a firefox -p linux64 -v 45.4.0esr --build-number=1
     {'args': {'application': 'firefox',
               'platform': 'linux64',
-              'version': '31.8.0esr',
+              'version': '45.4.0esr',
               'build_number': 1},
-     'url': 'firefox/candidates/31.8.0esr-candidates/build1/linux-x86_64/en-US/firefox-31.8.0esr.tar.bz2'},
+     'url': 'firefox/candidates/45.4.0esr-candidates/build1/linux-x86_64/en-US/firefox-45.4.0esr.tar.bz2'},
 
-    # -a firefox -p mac -v 31.8.0esr --build-number=1
+    # -a firefox -p mac -v 45.4.0esr --build-number=1
     {'args': {'application': 'firefox',
               'platform': 'mac',
-              'version': '31.8.0esr',
+              'version': '45.4.0esr',
               'build_number': 1},
-     'url': 'firefox/candidates/31.8.0esr-candidates/build1/mac/en-US/Firefox 31.8.0esr.dmg'},
+     'url': 'firefox/candidates/45.4.0esr-candidates/build1/mac/en-US/Firefox 45.4.0esr.dmg'},
 
-    # -a firefox -p win32 -v 31.8.0esr -l de --build-number=1
+    # -a firefox -p win32 -v 45.4.0esr -l de --build-number=1
     {'args': {'application': 'firefox',
               'locale': 'de',
               'platform': 'win32',
-              'version': '31.8.0esr',
+              'version': '45.4.0esr',
               'build_number': 1},
-     'url': 'firefox/candidates/31.8.0esr-candidates/build1/win32/de/Firefox Setup 31.8.0esr.exe'},
+     'url': 'firefox/candidates/45.4.0esr-candidates/build1/win32/de/Firefox Setup 45.4.0esr.exe'},
 ]
 
 tests_daily_scraper = [

--- a/tests/remote/test_thunderbird.py
+++ b/tests/remote/test_thunderbird.py
@@ -55,50 +55,50 @@ tests_release_scraper = [
 ]
 
 tests_candidate_scraper = [
-    # -a thunderbird -p linux -v 31.8.0
+    # -a thunderbird -p linux -v 45.4.0
     {'args': {'application': 'thunderbird',
               'platform': 'linux',
-              'version': '31.8.0'},
-     'url': 'thunderbird/candidates/31.8.0-candidates/build1/linux-i686/en-US/thunderbird-31.8.0.tar.bz2'},
+              'version': '45.4.0'},
+     'url': 'thunderbird/candidates/45.4.0-candidates/build1/linux-i686/en-US/thunderbird-45.4.0.tar.bz2'},
 
-    # -a thunderbird -p linux64 -v 31.8.0
+    # -a thunderbird -p linux64 -v 45.4.0
     {'args': {'application': 'thunderbird',
               'platform': 'linux64',
-              'version': '31.8.0'},
-     'url': 'thunderbird/candidates/31.8.0-candidates/build1/linux-x86_64/en-US/thunderbird-31.8.0.tar.bz2'},
+              'version': '45.4.0'},
+     'url': 'thunderbird/candidates/45.4.0-candidates/build1/linux-x86_64/en-US/thunderbird-45.4.0.tar.bz2'},
 
-    # -a thunderbird -p mac -v 31.8.0
+    # -a thunderbird -p mac -v 45.4.0
     {'args': {'application': 'thunderbird',
               'platform': 'mac',
-              'version': '31.8.0'},
-     'url': 'thunderbird/candidates/31.8.0-candidates/build1/mac/en-US/Thunderbird 31.8.0.dmg'},
+              'version': '45.4.0'},
+     'url': 'thunderbird/candidates/45.4.0-candidates/build1/mac/en-US/Thunderbird 45.4.0.dmg'},
 
-    # -a thunderbird -p win32 -v 31.8.0
+    # -a thunderbird -p win32 -v 45.4.0
     {'args': {'application': 'thunderbird',
               'platform': 'win32',
-              'version': '31.8.0'},
-     'url': 'thunderbird/candidates/31.8.0-candidates/build1/win32/en-US/Thunderbird Setup 31.8.0.exe'},
+              'version': '45.4.0'},
+     'url': 'thunderbird/candidates/45.4.0-candidates/build1/win32/en-US/Thunderbird Setup 45.4.0.exe'},
 
-    # -a thunderbird -p win32 -v 31.8.0 -l cs
+    # -a thunderbird -p win32 -v 45.4.0 -l cs
     {'args': {'application': 'thunderbird',
               'locale': 'cs',
               'platform': 'win32',
-              'version': '31.8.0'},
-     'url': 'thunderbird/candidates/31.8.0-candidates/build1/win32/cs/Thunderbird Setup 31.8.0.exe'},
+              'version': '45.4.0'},
+     'url': 'thunderbird/candidates/45.4.0-candidates/build1/win32/cs/Thunderbird Setup 45.4.0.exe'},
 
-    # -a thunderbird -p win32 -v 31.8.0 -l en-GB
+    # -a thunderbird -p win32 -v 45.4.0 -l en-GB
     {'args': {'application': 'thunderbird',
               'locale': 'en-GB',
               'platform': 'win32',
-              'version': '31.8.0'},
-     'url': 'thunderbird/candidates/31.8.0-candidates/build1/win32/en-GB/Thunderbird Setup 31.8.0.exe'},
+              'version': '45.4.0'},
+     'url': 'thunderbird/candidates/45.4.0-candidates/build1/win32/en-GB/Thunderbird Setup 45.4.0.exe'},
 
-    # -a thunderbird -p win32 -v 31.8.0
+    # -a thunderbird -p win32 -v 45.4.0
     {'args': {'application': 'thunderbird',
               'build_number': '1',
               'platform': 'win32',
-              'version': '31.8.0'},
-     'url': 'thunderbird/candidates/31.8.0-candidates/build1/win32/en-US/Thunderbird Setup 31.8.0.exe'},
+              'version': '45.4.0'},
+     'url': 'thunderbird/candidates/45.4.0-candidates/build1/win32/en-US/Thunderbird Setup 45.4.0.exe'},
 ]
 
 tests_daily_scraper = [


### PR DESCRIPTION
This PR fixes issue #413 by just updating the versions.