### PR TITLE
Add coverage to tox and py.test (#396)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+# configuration for coverage.py
+[run]
+source = mozdownload
+
+[report]
+exclude_lines =
+    # Don't complain if tests don't hit defensive assertion code
+    raise NotImplementedError
+    # pass instructions does need to be tested
+    pass
+    # Don't complain if non-runnable code isn't run
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 build
 dist
+htmlcov

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
 
 commands =
     pylama mozdownload
-    coverage run --source mozdownload -m py.test {posargs}
+    coverage run -m py.test {posargs}
 
 [testenv:clean]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27
+envlist = clean,py27,stats
 
 [testenv:py27]
 deps =
+    coverage
     mock
     mozfile >= 1.1
     mozprocess >= 0.22
@@ -12,4 +13,13 @@ deps =
 
 commands =
     pylama mozdownload
-    py.test {posargs}
+    coverage run --source mozdownload -m py.test {posargs}
+
+[testenv:clean]
+commands=
+  coverage erase
+
+[testenv:stats]
+commands=
+    coverage report --omit='.tox/*'
+    coverage html --omit='.tox/*'


### PR DESCRIPTION
This PR addresses issue #396.

I used the following pages as a reference on how to do it.

Combining coverage and tox
http://schinckel.net/2014/07/28/tox-and-coverage.py/

Combining coverage and py.test
http://stackoverflow.com/questions/16404716/using-py-test-with-coverage-doesnt-include-imports

There is a warning given when calling `testenv:clean` and `testenv:stats`, but to my understanding, this is a bug. **Can we live with it or should I look for an alternative?**
https://bugs.launchpad.net/rally/+bug/1464495

Output looks as follows:

```
(mozdownload) nebelhom@nebelhom-TravelMate-P273:~/Mozilla/mozdownload/mozdownload$ tox
GLOB sdist-make: /home/nebelhom/Mozilla/mozdownload/mozdownload/setup.py
clean inst-nodeps: /home/nebelhom/Mozilla/mozdownload/mozdownload/.tox/dist/mozdownload-1.21.zip
clean installed: mohawk==0.3.3,mozdownload==1.21,mozfile==1.2,mozinfo==0.9,progressbar==2.2,redo==1.5,requests==2.9.1,requests-hawk==1.0.0,six==1.10.0,treeherder-client==3.0.0
clean runtests: PYTHONHASHSEED='1884892782'
clean runtests: commands[0] | coverage erase
WARNING:test command found but not installed in testenv
  cmd: /usr/local/bin/coverage
  env: /home/nebelhom/Mozilla/mozdownload/mozdownload/.tox/clean
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.
py27 inst-nodeps: /home/nebelhom/Mozilla/mozdownload/mozdownload/.tox/dist/mozdownload-1.21.zip
py27 installed: coverage==4.2,funcsigs==1.0.2,mccabe==0.5.2,mock==2.0.0,mohawk==0.3.3,mozdownload==1.21,mozfile==1.2,mozinfo==0.9,mozprocess==0.23,pbr==1.10.0,progressbar==2.2,py==1.4.31,pycodestyle==2.2.0,pydocstyle==1.1.1,pyflakes==1.3.0,pylama==7.3.1,pytest==3.0.4,redo==1.5,requests==2.9.1,requests-hawk==1.0.0,six==1.10.0,treeherder-client==3.0.0,wptserve==1.4.0
py27 runtests: PYTHONHASHSEED='1884892782'
py27 runtests: commands[0] | pylama mozdownload
py27 runtests: commands[1] | coverage run --source mozdownload -m py.test
========================================================================== test session starts ===========================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/nebelhom/Mozilla/mozdownload/mozdownload, inifile: 
plugins: pylama-7.3.1
collected 47 items 

tests/base_scraper/test_base_scraper.py .....
tests/cli/test_cli_arguments.py .
tests/cli/test_correct_scraper.py .
tests/cli/test_output.py .
tests/daily_scraper/test_daily_indices.py .
tests/daily_scraper/test_daily_scraper.py .
tests/daily_scraper/test_invalid_branch.py .
tests/daily_scraper/test_invalid_date.py .
tests/daily_scraper/test_revision.py ..
tests/direct_scraper/test_direct_scraper.py .
tests/directory_parser/test_directory_parser.py ...
tests/factory/test_factory_invalid_options.py .....
tests/factory/test_factory_scraper.py .
tests/release_candidate_scraper/test_release_candidate_scraper.py .
tests/release_candidate_scraper/test_release_candidate_scraper_indices.py .
tests/release_candidate_scraper/test_release_candidate_scraper_latest.py .
tests/release_scraper/test_release_scraper.py .
tests/release_scraper/test_release_scraper_latest.py .
tests/remote/test_fennec.py .
tests/remote/test_firefox.py ....s
tests/remote/test_thunderbird.py .s..
tests/tinderbox_scraper/test_invalid_date_tinderbox.py .
tests/tinderbox_scraper/test_revision_tinderbox.py ..
tests/tinderbox_scraper/test_tinderbox_scraper.py .
tests/treeherder/test_api.py ..
tests/try_scraper/test_invalid_revision.py .
tests/try_scraper/test_try_scraper.py .

================================================================= 45 passed, 2 skipped in 171.50 seconds =================================================================
stats inst-nodeps: /home/nebelhom/Mozilla/mozdownload/mozdownload/.tox/dist/mozdownload-1.21.zip
stats installed: mohawk==0.3.3,mozdownload==1.21,mozfile==1.2,mozinfo==0.9,progressbar==2.2,redo==1.5,requests==2.9.1,requests-hawk==1.0.0,six==1.10.0,treeherder-client==3.0.0
stats runtests: PYTHONHASHSEED='1884892782'
stats runtests: commands[0] | coverage report --omit=.tox/*
WARNING:test command found but not installed in testenv
  cmd: /usr/local/bin/coverage
  env: /home/nebelhom/Mozilla/mozdownload/mozdownload/.tox/stats
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.
Name                        Stmts   Miss  Cover
-----------------------------------------------
mozdownload/__init__.py         6      0   100%
mozdownload/cli.py             52      4    92%
mozdownload/errors.py          16      3    81%
mozdownload/factory.py         22      4    82%
mozdownload/parser.py          43      0   100%
mozdownload/scraper.py        469     40    91%
mozdownload/timezones.py       18      1    94%
mozdownload/treeherder.py      46      2    96%
mozdownload/utils.py           16      0   100%
-----------------------------------------------
TOTAL                         688     54    92%
stats runtests: commands[1] | coverage html --omit=.tox/*
WARNING:test command found but not installed in testenv
  cmd: /usr/local/bin/coverage
  env: /home/nebelhom/Mozilla/mozdownload/mozdownload/.tox/stats
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.
________________________________________________________________________________ summary _________________________________________________________________________________
  clean: commands succeeded
  py27: commands succeeded
  stats: commands succeeded
  congratulations :)
```
