### PR TITLE
Bump package dependencies for more relaxed version requirements (#430)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ def get_version():
                       read('mozdownload', 'cli.py'), re.M)[0]
 
 deps = ['mozinfo >= 0.9',
-        'progressbar == 2.2',
-        'redo == 1.5',
-        'requests == 2.9.1',
-        'treeherder-client == 3.0.0',
+        'progressbar == 2.3',
+        'redo == 1.6',
+        'requests >= 2.9.1, <3.0.0',
+        'treeherder-client >= 3.0.0, <4.0.0',
         ]
 
 setup(name='mozdownload',


### PR DESCRIPTION
This fixes issue #430. It allows us to be more flexible in terms of which package versions are installed. It means that we allow all minor versions which should come without API changes.