### PR TITLE
Remove left-over comment for exclusion of pycodestyle warnings of bare excepts (#426)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,6 @@ max_line_length = 100
 
 [pylama:pycodestyle]
 max_line_length = 100
-# Fix in Issue #426
-ignore = E722
 
 [pylama:pylint]
 max_line_length = 100


### PR DESCRIPTION
Comment only change to fix the remaining items for issue #426. I will go ahead and get it landed when tests are passing.