### PR TITLE
Remove call to unittest.main() from all test modules (#470)

### DIFF
--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 
 import mozhttpd_base_test as mhttpd
 import requests
@@ -134,7 +133,3 @@ class TestBaseScraper(mhttpd.MozHttpdBaseTest):
                                             destination=destination,
                                             logger=self.logger)
         self.assertEqual(scraper.destination, destination)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/cli/test_cli_print_url.py
+++ b/tests/cli/test_cli_print_url.py
@@ -15,13 +15,10 @@ class TestPrintUrlArgument(unittest.TestCase):
         url = r'https://raw.github.com/mozilla/mozdownload/master/README.md'
         try:
             args = ['mozdownload',
-                '--url={url}'.format(url=url),
-                '--print-url']
+                    '--url={url}'.format(url=url),
+                    '--print-url']
             output = subprocess.check_output(args, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             output = e.output
 
         self.assertRegexpMatches(output, url)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/daily_scraper/test_daily_indices.py
+++ b/tests/daily_scraper/test_daily_indices.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mozdownload import DailyScraper
 import mozhttpd_base_test as mhttpd
 
@@ -54,5 +52,3 @@ class TestDailyScraperIndices(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.build_index, entry['build_index'])
             self.assertEqual(scraper.builds, entry['builds'])
 
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/daily_scraper/test_daily_scraper.py
+++ b/tests/daily_scraper/test_daily_scraper.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 import urllib
 
 from mozdownload import DailyScraper
@@ -313,7 +312,3 @@ class TestDailyScraper(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.filename, expected_target)
             self.assertEqual(urllib.unquote(scraper.url),
                              urljoin(self.wdir, entry['url']))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/daily_scraper/test_invalid_branch.py
+++ b/tests/daily_scraper/test_invalid_branch.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mozdownload import DailyScraper
 import mozdownload.errors as errors
 
@@ -36,7 +34,3 @@ class TestDailyScraperInvalidBranch(mhttpd.MozHttpdBaseTest):
                               base_url=self.wdir,
                               logger=self.logger,
                               **entry['args'])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/daily_scraper/test_invalid_date.py
+++ b/tests/daily_scraper/test_invalid_date.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mozdownload import DailyScraper
 
 import mozhttpd_base_test as mhttpd
@@ -46,7 +44,3 @@ class TestDailyScraperInvalidParameters(mhttpd.MozHttpdBaseTest):
                               base_url=self.wdir,
                               logger=self.logger,
                               **entry['args'])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/daily_scraper/test_revision.py
+++ b/tests/daily_scraper/test_revision.py
@@ -4,10 +4,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mock import patch
 from mozdownload import DailyScraper, errors
+
 import mozhttpd_base_test as mhttpd
 
 
@@ -37,7 +36,3 @@ class TestDailyScraperRevision(mhttpd.MozHttpdBaseTest):
                          logger=self.logger,
                          platform='linux',
                          revision='not_valid')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/direct_scraper/test_direct_scraper.py
+++ b/tests/direct_scraper/test_direct_scraper.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 
 from mozdownload import DirectScraper
 import mozdownload.errors as errors
@@ -32,7 +31,3 @@ class TestDirectScraper(mhttpd.MozHttpdBaseTest):
         scraper.download()
         self.assertTrue(os.path.isfile(os.path.join(self.temp_dir,
                                                     scraper.filename)))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/directory_parser/test_directory_parser.py
+++ b/tests/directory_parser/test_directory_parser.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 
 from mozdownload.parser import DirectoryParser
 from mozdownload.utils import urljoin
@@ -66,7 +65,3 @@ class DirectoryParserTest(mhttpd.MozHttpdBaseTest):
         contents = os.listdir(folder_path)
         contents.sort()
         self.assertEqual(parser.entries, contents)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/release_candidate_scraper/test_release_candidate_scraper.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 import urllib
 
 from mozdownload import ReleaseCandidateScraper
@@ -133,7 +132,3 @@ class ReleaseCandidateScraperTest(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.filename, expected_filename)
             self.assertEqual(urllib.unquote(scraper.url),
                              urljoin(self.wdir, entry['url']))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mozdownload import ReleaseCandidateScraper
 
 import mozhttpd_base_test as mhttpd
@@ -58,6 +56,3 @@ class ReleaseCandidateScraperTest_build_indices(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.build_index, entry['build_index'])
             self.assertEqual(scraper.build_number, entry['build_number'])
             self.assertEqual(scraper.builds, entry['builds'])
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/release_candidate_scraper/test_release_candidate_scraper_latest.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper_latest.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 import urllib
 
 from mozdownload import ReleaseCandidateScraper
@@ -203,7 +202,3 @@ class ReleaseCandidateScraperTest(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.filename, expected_filename)
             self.assertEqual(urllib.unquote(scraper.url),
                              urljoin(self.wdir, entry['url']))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/release_scraper/test_release_scraper.py
+++ b/tests/release_scraper/test_release_scraper.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 import urllib
 
 from mozdownload import ReleaseScraper
@@ -132,7 +131,3 @@ class ReleaseScraperTest(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.filename, expected_filename)
             self.assertEqual(urllib.unquote(scraper.url),
                              urljoin(self.wdir, entry['url']))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/release_scraper/test_release_scraper_latest.py
+++ b/tests/release_scraper/test_release_scraper_latest.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 import urllib
 
 from mozdownload import ReleaseScraper
@@ -204,7 +203,3 @@ class ReleaseScraperTest(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.filename, expected_filename)
             self.assertEqual(urllib.unquote(scraper.url),
                              urljoin(self.wdir, entry['url']))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/remote/test_fennec.py
+++ b/tests/remote/test_fennec.py
@@ -97,7 +97,3 @@ class FennecRemoteTests(unittest.TestCase):
             mozdownload.DailyScraper(destination=self.temp_dir,
                                      logger=self.logger,
                                      **test['args'])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/remote/test_firefox.py
+++ b/tests/remote/test_firefox.py
@@ -6,7 +6,6 @@
 
 """Test all scraper classes for Firefox against the remote server"""
 
-import unittest
 import urllib
 
 import pytest
@@ -116,10 +115,6 @@ def test_tinderbox_scraper(tmpdir, args):
     mozdownload.TinderboxScraper(destination=tmpdir, **args)
 
 
-@unittest.skip('Not testable as long as we cannot grab a latest build')
+@pytest.mark.skip(reason='Not testable as long as we cannot grab a latest build')
 def test_try_scraper():
     pass
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/remote/test_thunderbird.py
+++ b/tests/remote/test_thunderbird.py
@@ -249,7 +249,3 @@ class ThunderbirdRemoteTests(unittest.TestCase):
             mozdownload.TinderboxScraper(destination=self.temp_dir,
                                          logger=self.logger,
                                          **test['args'])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/tinderbox_scraper/test_invalid_date_tinderbox.py
+++ b/tests/tinderbox_scraper/test_invalid_date_tinderbox.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mozdownload import TinderboxScraper
 
 import mozhttpd_base_test as mhttpd
@@ -50,7 +48,3 @@ class TestTinderboxScraperInvalidParameters(mhttpd.MozHttpdBaseTest):
                               base_url=self.wdir,
                               logger=self.logger,
                               **entry['args'])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/tinderbox_scraper/test_revision_tinderbox.py
+++ b/tests/tinderbox_scraper/test_revision_tinderbox.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mock import patch
 
 from mozdownload import TinderboxScraper, errors
@@ -38,7 +36,3 @@ class TestTinderboxScraperRevision(mhttpd.MozHttpdBaseTest):
                              logger=self.logger,
                              platform='linux',
                              revision='not_valid')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/tinderbox_scraper/test_tinderbox_scraper.py
+++ b/tests/tinderbox_scraper/test_tinderbox_scraper.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 import urllib
 
 from mozdownload import TinderboxScraper
@@ -281,7 +280,3 @@ class TinderboxScraperTest(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.filename, expected_filename)
             self.assertEqual(urllib.unquote(scraper.url),
                              urljoin(self.wdir, entry['url']))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/treeherder/test_api.py
+++ b/tests/treeherder/test_api.py
@@ -6,7 +6,6 @@
 
 import json
 import os
-import unittest
 import urlparse
 
 from wptserve.handlers import json_handler
@@ -84,7 +83,3 @@ class TestAPIInvalidUsage(mhttpd.MozHttpdBaseTest):
         builds = th.query_builds_by_revision('29258f59e545')
 
         self.assertEqual(builds, [])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/try_scraper/test_invalid_revision.py
+++ b/tests/try_scraper/test_invalid_revision.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from mock import patch
 
 from mozdownload import TryScraper
@@ -28,7 +26,3 @@ class TestTryScraperInvalidParameters(mhttpd.MozHttpdBaseTest):
                        platform='win32',
                        revision='abc'
                        )
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/try_scraper/test_try_scraper.py
+++ b/tests/try_scraper/test_try_scraper.py
@@ -5,7 +5,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import unittest
 import urllib
 
 from mock import patch
@@ -77,6 +76,3 @@ class TryScraperTest(mhttpd.MozHttpdBaseTest):
             self.assertEqual(scraper.filename, expected_filename)
             self.assertEqual(urllib.unquote(scraper.url),
                              urljoin(self.wdir, entry['url']))
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
As suggested by @davehunt on PR #467 we can remove all of those calls.