### PR TITLE
Invalid build number for candidate scraper should fail #445

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -696,14 +696,17 @@ class ReleaseCandidateScraper(ReleaseScraper):
         self.show_matching_builds(parser.entries)
         self.builds = parser.entries
         self.build_index = len(parser.entries) - 1
-        if self.build_number and \
-                ('build%s' % self.build_number) in self.builds:
-            self.builds = ['build%s' % self.build_number]
-            self.build_index = 0
-            self.logger.info('Selected build: build%s' % self.build_number)
+        
+        if (self.build_number):
+            if ('build%s' % self.build_number) in self.builds:
+                self.builds = ['build%s' % self.build_number]
+                self.build_index = 0
+                self.logger.info('Selected build: build%s' % self.build_number)
+            else:
+                raise errors.NotFoundError('Selected build does not exist', (u'build%s' % self.build_number))
         else:
-            raise errors.NotFoundError('Selected build does not exist', (u'build%s' % self.build_number))
-
+            self.logger.info('Selected build: %s' % (parser.entries[self.build_index]))
+            
     @property
     def candidate_build_list_regex(self):
         """Return the regex for the folder with the list of candidate builds."""

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -696,15 +696,13 @@ class ReleaseCandidateScraper(ReleaseScraper):
         self.show_matching_builds(parser.entries)
         self.builds = parser.entries
         self.build_index = len(parser.entries) - 1
-
         if self.build_number and \
                 ('build%s' % self.build_number) in self.builds:
             self.builds = ['build%s' % self.build_number]
             self.build_index = 0
             self.logger.info('Selected build: build%s' % self.build_number)
         else:
-            self.logger.info('Selected build: %s' %
-                             (parser.entries[self.build_index]))
+            raise errors.NotFoundError('Selected build does not exist', (u'build%s' % self.build_number))
 
     @property
     def candidate_build_list_regex(self):


### PR DESCRIPTION
Test Plan:
Executed the following commands and checked for desired behavior:
`mozdownload -t candidate -v 53.0 --build-number 2`
`mozdownload -t candidate -v 53.0 --build-number 6`

Note that I'm intending on writing a unit test for this bug to prevent future regressions, however I'm currently having significant issues understanding and executing the test suite. 

Whenever I run the tests using `tox` I get import errors from pretty much all of the tests, saying that they fail to import `mozdownload` - running the test python script directly returns import errors for `mozhttp_base_test`. This is despite all of these files definitely existing, as I can run mozdownload manually just fine.

It also appears that tests/release_candidate_scraper/tests_release_candidate_scraper_indices.py already contains a test for invalid build numbers, but I'm not really sure how it works? The code itself doesn't appear to be checking that an error is raised when an invalid build number is entered so I'm a bit stumped on how to go about that.

Any help would be much appreciated,
Toby