### PR TITLE
TestScraper: port unittest to pytest #468

### DIFF
--- a/tests/try_scraper/test_invalid_revision.py
+++ b/tests/try_scraper/test_invalid_revision.py
@@ -5,24 +5,18 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from mock import patch
-
+import pytest
 from mozdownload import TryScraper
 import mozdownload.errors as errors
-import mozhttpd_base_test as mhttpd
 
 
-class TestTryScraperInvalidParameters(mhttpd.MozHttpdBaseTest):
-    """test mozdownload TryScraper class with invalid parameters"""
+@patch('mozdownload.treeherder.Treeherder.query_builds_by_revision')
+def test_scraper(query_builds_by_revision, httpd, tmpdir):
+    """Testing download scenarios with invalid parameters for TryScraper"""
+    query_builds_by_revision.return_value = []
 
-    @patch('mozdownload.treeherder.Treeherder.query_builds_by_revision')
-    def test_scraper(self, query_builds_by_revision):
-        """Testing download scenarios with invalid parameters for TryScraper"""
-        query_builds_by_revision.return_value = []
-
-        with self.assertRaises(errors.NotFoundError):
-            TryScraper(destination=self.temp_dir,
-                       base_url=self.wdir,
-                       logger=self.logger,
-                       platform='win32',
-                       revision='abc'
-                       )
+    with pytest.raises(errors.NotFoundError):
+        assert TryScraper(destination=tmpdir,
+                          base_url=httpd.get_url(),
+                          platform='win32',
+                          revision='abc')

--- a/tests/try_scraper/test_try_scraper.py
+++ b/tests/try_scraper/test_try_scraper.py
@@ -6,73 +6,55 @@
 
 import os
 import urllib
-
+import pytest
 from mock import patch
-
 from mozdownload import TryScraper
 from mozdownload.utils import urljoin
-import mozhttpd_base_test as mhttpd
 
-firefox_tests = [
+@pytest.mark.parametrize("args,filename,url", [
     # -p mac64 --revision=8fcac92cfcad
-    {'args': {'platform': 'mac64',
-              'revision': '8fcac92cfcad'},
-     'filename': '8fcac92cfcad-firefox-38.0a1.en-US.mac.dmg',
-     'url': 'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
-            'try-macosx64/firefox-38.0a1.en-US.mac.dmg'},
+    ({'platform': 'mac64', 'revision': '8fcac92cfcad'},
+     '8fcac92cfcad-firefox-38.0a1.en-US.mac.dmg',
+     'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
+     'try-macosx64/firefox-38.0a1.en-US.mac.dmg'),
     # -p mac --revision=8fcac92cfcad
-    {'args': {'platform': 'mac',
-              'revision': '8fcac92cfcad'},
-     'filename': '8fcac92cfcad-firefox-38.0a1.en-US.mac.dmg',
-     'url': 'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
-            'try-macosx64/firefox-38.0a1.en-US.mac.dmg'},
+    ({'platform': 'mac', 'revision': '8fcac92cfcad'},
+     '8fcac92cfcad-firefox-38.0a1.en-US.mac.dmg',
+     'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
+     'try-macosx64/firefox-38.0a1.en-US.mac.dmg'),
     # -a firefox -p linux64 --revision=8fcac92cfcad
-    {'args': {'platform': 'linux64',
-              'revision': '8fcac92cfcad'},
-     'filename': '8fcac92cfcad-firefox-38.0a1.en-US.linux-x86_64.tar.bz2',
-     'url': 'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
-            'try-linux64/firefox-38.0a1.en-US.linux-x86_64.tar.bz2'},
+    ({'platform': 'linux64', 'revision': '8fcac92cfcad'},
+     '8fcac92cfcad-firefox-38.0a1.en-US.linux-x86_64.tar.bz2',
+     'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
+     'try-linux64/firefox-38.0a1.en-US.linux-x86_64.tar.bz2'),
     # -a firefox -p linux --revision=8fcac92cfcad --debug-build
-    {'args': {'platform': 'linux',
-              'revision': '8fcac92cfcad',
-              'debug_build': True},
-     'filename': '8fcac92cfcad-debug-firefox-38.0a1.en-US.linux-i686.tar.bz2',
-     'url': 'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
-            'try-linux-debug/firefox-38.0a1.en-US.linux-i686.tar.bz2'},
+    ({'platform': 'linux', 'revision': '8fcac92cfcad', 'debug_build': True},
+     '8fcac92cfcad-debug-firefox-38.0a1.en-US.linux-i686.tar.bz2',
+     'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
+     'try-linux-debug/firefox-38.0a1.en-US.linux-i686.tar.bz2'),
     # -a firefox -p win32 --revision=8fcac92cfcad
-    {'args': {'platform': 'win32',
-              'revision': '8fcac92cfcad'},
-     'filename': '8fcac92cfcad-firefox-38.0a1.en-US.win32.installer.exe',
-     'url': 'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
-            'try-win32/firefox-38.0a1.en-US.win32.installer.exe'},
+    ({'platform': 'win32', 'revision': '8fcac92cfcad'},
+     '8fcac92cfcad-firefox-38.0a1.en-US.win32.installer.exe',
+     'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
+     'try-win32/firefox-38.0a1.en-US.win32.installer.exe'),
     # -a firefox -p win64 --revision=8fcac92cfcad
-    {'args': {'platform': 'win64',
-              'revision': '8fcac92cfcad'},
-     'filename': '8fcac92cfcad-firefox-38.0a1.en-US.win64.installer.exe',
-     'url': 'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
-            'try-win64/firefox-38.0a1.en-US.win64.installer.exe'},
-]
-
-tests = firefox_tests
+    ({'platform': 'win64', 'revision': '8fcac92cfcad'},
+     '8fcac92cfcad-firefox-38.0a1.en-US.win64.installer.exe',
+     'firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/'
+     'try-win64/firefox-38.0a1.en-US.win64.installer.exe')
+])
 
 
-class TryScraperTest(mhttpd.MozHttpdBaseTest):
-    """test mozdownload TryScraper class"""
-
-    @patch('mozdownload.treeherder.Treeherder.query_builds_by_revision')
-    def test_scraper(self, query_builds_by_revision):
-        """Testing various download scenarios for TryScraper"""
-        query_builds_by_revision.return_value = [
-            '/firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/try-foobar/'
-        ]
-
-        for entry in tests:
-
-            scraper = TryScraper(destination=self.temp_dir,
-                                 base_url=self.wdir,
-                                 logger=self.logger,
-                                 **entry['args'])
-            expected_filename = os.path.join(self.temp_dir, entry['filename'])
-            self.assertEqual(scraper.filename, expected_filename)
-            self.assertEqual(urllib.unquote(scraper.url),
-                             urljoin(self.wdir, entry['url']))
+@patch('mozdownload.treeherder.Treeherder.query_builds_by_revision')
+def test_scraper(mock_query_builds_by_revision, httpd, tmpdir, args, filename, url):
+    """Testing various download scenarios for TryScraper"""
+    mock_query_builds_by_revision.return_value = [
+        '/firefox/try-builds/test-user@mozilla.com-8fcac92cfcad/try-foobar/'
+    ]
+    baseurl = httpd.get_url()
+    scraper = TryScraper(destination=str(tmpdir),
+                         base_url=baseurl,
+                         **args)
+    expected_filename = os.path.join(str(tmpdir), filename)
+    assert scraper.filename == expected_filename
+    assert urllib.unquote(scraper.url) == urljoin(baseurl, url)


### PR DESCRIPTION
 - Porting UnitTest code of tests/Pyscraper Folder using pytest library
-  Linting done on both the files.