### PR TITLE
Add support for verifying downloaded file's SHA-512 hash

### DIFF
--- a/mozdownload/cli.py
+++ b/mozdownload/cli.py
@@ -117,6 +117,10 @@ def parse_arguments(argv):
                         dest='username',
                         metavar='USERNAME',
                         help='Username for basic HTTP authentication.')
+    parser.add_argument('--verify',
+                        dest='verify',
+                        action='store_true',
+                        help='Verify the integrity of downloaded files')
     parser.add_argument('--version', '-v',
                         dest='version',
                         metavar='VERSION',

--- a/mozdownload/errors.py
+++ b/mozdownload/errors.py
@@ -47,6 +47,16 @@ class HashMismatchError(Exception):
 
     def __init__(self, filename):
         """Create an instance of an exception."""
-        self.message = ('The hash for %s is different from what was'
+        self.message = ('The checksum for %s is different from what was'
                         ' expected' % filename)
+        Exception.__init__(self, self.message)
+
+
+class HashNotFoundError(Exception):
+    """Exception for when a file's checksum cannot be found in a
+        list of checksums."""
+
+    def __init__(self, filename):
+        """Create an instance of an exception."""
+        self.message = 'A checksum for %s could not be found' % filename
         Exception.__init__(self, self.message)

--- a/mozdownload/errors.py
+++ b/mozdownload/errors.py
@@ -40,6 +40,7 @@ class TimeoutError(Exception):
         self.message = 'The download exceeded the allocated timeout'
         Exception.__init__(self, self.message)
 
+
 class HashMismatchError(Exception):
     """Exception for when the hash of a file does not match with
         what is provided."""
@@ -49,4 +50,3 @@ class HashMismatchError(Exception):
         self.message = ('The hash for %s is different from what was'
                         ' expected' % filename)
         Exception.__init__(self, self.message)
-

--- a/mozdownload/errors.py
+++ b/mozdownload/errors.py
@@ -39,3 +39,14 @@ class TimeoutError(Exception):
         """Create an instance of an exception."""
         self.message = 'The download exceeded the allocated timeout'
         Exception.__init__(self, self.message)
+
+class HashMismatchError(Exception):
+    """Exception for when the hash of a file does not match with
+        what is provided."""
+
+    def __init__(self, filename):
+        """Create an instance of an exception."""
+        self.message = ('The hash for %s is different from what was'
+                        ' expected' % filename)
+        Exception.__init__(self, self.message)
+

--- a/mozdownload/factory.py
+++ b/mozdownload/factory.py
@@ -48,6 +48,7 @@ class FactoryScraper(scraper.Scraper):
         :param revision: Revision of the build to download.
         :param timeout: Amount of time (in seconds) until a download times out.
         :param username: Username for basic HTTP authentication.
+        :param verify: Verify the integrity of downloaded files
         :param version: Version of the application to be downloaded.
 
         Daily builds:
@@ -86,6 +87,7 @@ class FactoryScraper(scraper.Scraper):
                             'retry_delay': kwargs.get('retry_delay', 10),
                             'timeout': kwargs.get('timeout'),
                             'username': kwargs.get('username'),
+                            'verify': kwargs.get('verify'),
                             }
 
         scraper_type_keywords = {

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -259,9 +259,9 @@ class Scraper(object):
                     self.logger.info('Checksum verified')
                     return
                 else:
-                    break
+                    raise errors.HashMismatchError(file_identifier)
         # Could not find the hash in the file
-        raise errors.HashMismatchError(file_identifier)
+        raise errors.HashNotFoundError(file_identifier)
 
     def get_build_info(self):
         """Return additional build information in subclasses if necessary."""

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -237,7 +237,10 @@ class Scraper(object):
     @property
     def checksum_destination(self):
         """Return the location that the checksum file will be downloaded to."""
-        return '%s.CHECKSUM' % self.filename
+        path_length = len(self.base_url) - len(APPLICATIONS_TO_FTP_DIRECTORY.get(self.application,
+                                                                                 self.application))
+        return os.path.join(self.destination,
+                            self.checksum_url[path_length - 1:].replace('/', '-'))
 
     def verify_checksum(self):
         """Verify the checksum of the downloaded file."""

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -260,7 +260,6 @@ class Scraper(object):
                     return
                 else:
                     break
-        
         # Could not find the hash in the file
         raise errors.HashMismatchError(file_identifier)
 
@@ -290,7 +289,7 @@ class Scraper(object):
                 self.verify_checksum()
             else:
                 self.logger.warn(('There is no checksum data available for this '
-                                    'file so it will not be checked'))
+                                  'file so it will not be checked'))
 
     def download_file(self, url, filename):
         """Download a file."""
@@ -790,9 +789,9 @@ class ReleaseCandidateScraper(ReleaseScraper):
     @property
     def checksum_url(self):
         """Return the location of the checksum file for the download"""
-        return urljoin(self.base_url, self.candidate_build_list_regex, 
-                        self.builds[self.build_index] if self.build_number is None 
-                        else 'build%s' % self.build_number, 'SHA512SUMS')
+        return urljoin(self.base_url, self.candidate_build_list_regex,
+                       self.builds[self.build_index] if self.build_number is None
+                       else 'build%s' % self.build_number, 'SHA512SUMS')
 
     def build_filename(self, binary):
         """Return the proposed filename with extension for the binary."""

--- a/mozdownload/utils.py
+++ b/mozdownload/utils.py
@@ -43,4 +43,3 @@ def create_sha512(path):
             s.update(data)
 
     return s.hexdigest()
-

--- a/mozdownload/utils.py
+++ b/mozdownload/utils.py
@@ -30,3 +30,17 @@ def create_md5(path):
             m.update(data)
 
     return m.hexdigest()
+
+
+def create_sha512(path):
+    """Create the SHA-512 hash of a file using the hashlib library."""
+    s = hashlib.sha512()
+    with open(path, 'rb') as f:
+        while True:
+            data = f.read(8192)
+            if not data:
+                break
+            s.update(data)
+
+    return s.hexdigest()
+


### PR DESCRIPTION
For Issue #241.

I have tested this manually with the following commands:
`mozdownload --version=latest --verify`
`mozdownload --version=latest-beta --verify`
`mozdownload --version=latest-esr --verify`
`mozdownload --type candidate --version=latest --verify`
`mozdownload --application=thunderbird --version=latest --verify`
`mozdownload --type=daily --version=latest --verify`
`mozdownload --type=daily --version=release --verify`
`mozdownload --type=daily --version=tinderbox --verify`
`mozdownload --url=https://raw.github.com/mozilla/mozdownload/master/README.md --verify`
For direct downloads there is just a warning that there is no checksum data expected.

I haven't added any tests because I'm not sure of a good way to do so while avoiding actually downloading things.