### PR TITLE
Enable auth test in test_base_scraper.py

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,4 +2,4 @@ coveralls==1.8.1
 pytest==4.6.3
 pytest-cov==2.7.1
 pytest-mock==1.10.4
-wptserve==2.0
+wptserve==3.0

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -68,8 +68,8 @@ def test_not_implemented(tmpdir, attr):
 
 
 def test_invalid_authentication(httpd, tmpdir):
-    test_url = urljoin(httpd.get_url(), 'http_auth')
-    scraper = mozdownload.DirectScraper(destination=str(tmpdir), url=test_url)
+    basic_auth_url = urljoin(httpd.get_url(), 'basic_auth')
+    scraper = mozdownload.DirectScraper(destination=str(tmpdir), url=basic_auth_url)
     with pytest.raises(requests.exceptions.HTTPError):
         scraper.download()
 
@@ -77,13 +77,13 @@ def test_invalid_authentication(httpd, tmpdir):
 def test_valid_authentication(httpd, tmpdir):
     username = 'mozilla'
     password = 'mozilla'
-    test_url = urljoin(httpd.get_url(), 'http_auth?username={0}&password={1}'.format(username, password))
+    basic_auth_url = urljoin(httpd.get_url(), 'basic_auth')
     scraper = mozdownload.DirectScraper(destination=str(tmpdir),
-                                        url=test_url,
+                                        url=basic_auth_url,
                                         username=username,
                                         password=password)
     scraper.download()
-    assert os.path.isfile(os.path.join(str(tmpdir), 'http_auth'))
+    assert os.path.isfile(os.path.join(str(tmpdir), 'basic_auth'))
 
 
 def test_destination_as_directory(httpd, tmpdir):

--- a/tests/base_scraper/test_base_scraper.py
+++ b/tests/base_scraper/test_base_scraper.py
@@ -67,25 +67,23 @@ def test_not_implemented(tmpdir, attr):
         scraper.build_filename('invalid binary')
 
 
-@pytest.mark.skip(reason="Permanent failure due to mozqa.com not available anymore (#492)")
-def test_invalid_authentication(tmpdir):
-    basic_auth_url = 'http://mozqa.com/data/mozqa.com/http_auth/basic/'
-    scraper = mozdownload.DirectScraper(destination=str(tmpdir), url=basic_auth_url)
+def test_invalid_authentication(httpd, tmpdir):
+    test_url = urljoin(httpd.get_url(), 'http_auth')
+    scraper = mozdownload.DirectScraper(destination=str(tmpdir), url=test_url)
     with pytest.raises(requests.exceptions.HTTPError):
         scraper.download()
 
 
-@pytest.mark.skip(reason="Permanent failure due to mozqa.com not available anymore (#492)")
-def test_valid_authentication(tmpdir):
+def test_valid_authentication(httpd, tmpdir):
     username = 'mozilla'
     password = 'mozilla'
-    basic_auth_url = 'http://mozqa.com/data/mozqa.com/http_auth/basic/'
+    test_url = urljoin(httpd.get_url(), 'http_auth?username={0}&password={1}'.format(username, password))
     scraper = mozdownload.DirectScraper(destination=str(tmpdir),
-                                        url=basic_auth_url,
+                                        url=test_url,
                                         username=username,
                                         password=password)
     scraper.download()
-    assert os.path.isfile(os.path.join(str(tmpdir), 'mozqa.com'))
+    assert os.path.isfile(os.path.join(str(tmpdir), 'http_auth'))
 
 
 def test_destination_as_directory(httpd, tmpdir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,60 @@
+import base64
 import os
 
 import pytest
+from six.moves.urllib.parse import parse_qs, urlparse
 
-from wptserve import server
+from wptserve import (
+    handlers,
+    request,
+    routes as default_routes,
+    server,
+)
+
+class Authentication(request.Authentication):
+    """Override the faulty decode_basic method in request.Authentication
+       The original method uses base64.decodestring which gives an error if a str
+       is passed instead of a bytestring.
+       base64.b64decode works on both str and bytestring"""
+    def decode_basic(self, data):
+        decoded_data = base64.b64decode(data).decode()
+        return decoded_data.split(":", 1)
+
+@handlers.handler
+def http_auth_handler(req, response):
+    # Allow the test to specify the username and password
+
+    url_fragments = urlparse(req.url)
+    query_options = parse_qs(url_fragments.query)
+    username = query_options.get("username", ["guest"])[0]
+    password = query_options.get("password", ["guest"])[0]
+
+    auth = Authentication(req.headers)
+    content = """<!doctype html>
+        <title>HTTP Authentication</title>
+        <p id="status">{}</p>"""
+
+    if auth.username == username and auth.password == password:
+        response.status = 200
+        response.content = content.format("success")
+
+    else:
+        response.status = 401
+        response.headers.set("WWW-Authenticate", "Basic realm=\"secret\"")
+        response.content = content.format("restricted")
 
 
 @pytest.fixture
 def httpd():
     HERE = os.path.dirname(os.path.abspath(__file__))
+    routes = [("GET", "/http_auth", http_auth_handler),
+              ]
+    routes.extend(default_routes.routes)
     httpd = server.WebTestHttpd(
         host="127.0.0.1",
         port=8080,
         doc_root=os.path.join(HERE, 'data'),
+        routes=routes,
         )
     httpd.start(block=False)
     yield httpd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,25 +11,15 @@ from wptserve import (
     server,
 )
 
-class Authentication(request.Authentication):
-    """Override the faulty decode_basic method in request.Authentication
-       The original method uses base64.decodestring which gives an error if a str
-       is passed instead of a bytestring.
-       base64.b64decode works on both str and bytestring"""
-    def decode_basic(self, data):
-        decoded_data = base64.b64decode(data).decode()
-        return decoded_data.split(":", 1)
 
 @handlers.handler
-def http_auth_handler(req, response):
+def basic_auth_handler(req, response):
     # Allow the test to specify the username and password
 
-    url_fragments = urlparse(req.url)
-    query_options = parse_qs(url_fragments.query)
-    username = query_options.get("username", ["guest"])[0]
-    password = query_options.get("password", ["guest"])[0]
+    username = b"mozilla"
+    password = b"mozilla"
 
-    auth = Authentication(req.headers)
+    auth = request.Authentication(req.headers)
     content = """<!doctype html>
         <title>HTTP Authentication</title>
         <p id="status">{}</p>"""
@@ -47,8 +37,9 @@ def http_auth_handler(req, response):
 @pytest.fixture
 def httpd():
     HERE = os.path.dirname(os.path.abspath(__file__))
-    routes = [("GET", "/http_auth", http_auth_handler),
-              ]
+    routes = [
+        ("GET", "/basic_auth", basic_auth_handler),
+    ]
     routes.extend(default_routes.routes)
     httpd = server.WebTestHttpd(
         host="127.0.0.1",


### PR DESCRIPTION
Fixes #492 

- Adds a custom auth handler and register a route
- Overrides the `decode_basic` method of request.Authentication
  -  uses the right base64 decode function and fixes the bytes/str error
- enables the auth tests

The `decode_basic` call in `request.Authentication` would fail in py3 as it uses `base64.decodestring` which expects a byte-like array. Hence overrode this to use `base64.b64decode`

### NOTE:
wptserve==2.0 from PyPI has this issue. wptserve has since been moved to https://github.com/web-platform-tests/wpt where this has been fixed.