### PR TITLE
Fix an issue with invalid build number for candidate scraper

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -707,9 +707,7 @@ class ReleaseCandidateScraper(ReleaseScraper):
             self.build_index = 0
             self.logger.info('Selected build: build%s' % self.build_number)
         else:
-            message = 'Selected build not available!'
-            self.logger.info(message)
-            raise errors.NotSupportedError(message)
+            raise errors.NotSupportedError('Selected build not available')
 
     @property
     def candidate_build_list_regex(self):

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -697,14 +697,19 @@ class ReleaseCandidateScraper(ReleaseScraper):
         self.builds = parser.entries
         self.build_index = len(parser.entries) - 1
 
-        if self.build_number and \
-                ('build%s' % self.build_number) in self.builds:
+        if self.build_number is None:
+            self.logger.info('Selected build: %s' %
+                             (parser.entries[self.build_index]))
+            return
+
+        if ('build%s' % self.build_number) in self.builds:
             self.builds = ['build%s' % self.build_number]
             self.build_index = 0
             self.logger.info('Selected build: build%s' % self.build_number)
         else:
-            self.logger.info('Selected build: %s' %
-                             (parser.entries[self.build_index]))
+            message = 'Selected build not available!'
+            self.logger.info(message)
+            raise errors.NotSupportedError(message)
 
     @property
     def candidate_build_list_regex(self):

--- a/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from mozdownload import ReleaseCandidateScraper, errors
+from mozdownload import errors, ReleaseCandidateScraper
 
 
 @pytest.mark.parametrize("args,build_index,build_number,builds", [

--- a/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
+++ b/tests/release_candidate_scraper/test_release_candidate_scraper_indices.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from mozdownload import ReleaseCandidateScraper
+from mozdownload import ReleaseCandidateScraper, errors
 
 
 @pytest.mark.parametrize("args,build_index,build_number,builds", [
@@ -14,14 +14,21 @@ from mozdownload import ReleaseCandidateScraper
      '0', '1', ['build1']),
     ({'application': 'firefox', 'build_number': '3', 'platform': 'mac', 'version': '23.0.1'},
      '0', '3', ['build3']),
-    ({'application': 'firefox', 'build_number': '2', 'platform': 'linux', 'version': '23.0.1'},
-     '1', '2', ['build1', 'build3']),
 ])
 
 def test_build_indices(httpd, tmpdir, args, build_index, build_number, builds):
     """Testing indices in choosing builds for ReleaseCandidateScraper"""
 
     scraper = ReleaseCandidateScraper(destination=tmpdir, base_url=httpd.get_url(), **args)
+
     assert scraper.build_index == int(build_index)
     assert scraper.build_number == build_number
     assert scraper.builds == builds
+
+def test_invalid_build_number(httpd, tmpdir):
+    """Testing invalid build number when choosing builds for ReleaseCandidateScraper"""
+
+    args = {'application': 'firefox', 'build_number': '2', 'platform': 'linux', 'version': '23.0.1'}
+
+    with pytest.raises(errors.NotSupportedError):
+        ReleaseCandidateScraper(destination=tmpdir, base_url=httpd.get_url(), **args)

--- a/tests/remote/test_devedition.py
+++ b/tests/remote/test_devedition.py
@@ -39,18 +39,18 @@ def test_release_scraper(tmpdir, args, url):
 
 @pytest.mark.ci_only
 @pytest.mark.parametrize("args,url", [
-    ({'application': 'devedition', 'platform': 'linux', 'version': '60.0b1', 'build_number': 1},
+    ({'application': 'devedition', 'platform': 'linux', 'version': '60.0b1', 'build_number': 3},
      'devedition/candidates/60.0b1-candidates/build3/linux-i686/en-US/firefox-60.0b1.tar.bz2'),
-    ({'application': 'devedition', 'platform': 'linux64', 'version': '60.0b1', 'build_number': 1},
+    ({'application': 'devedition', 'platform': 'linux64', 'version': '60.0b1', 'build_number': 3},
      'devedition/candidates/60.0b1-candidates/build3/linux-x86_64/en-US/firefox-60.0b1.tar.bz2'),  # noqa
-    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 1},
+    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 3},
      'devedition/candidates/60.0b1-candidates/build3/mac/en-US/Firefox 60.0b1.dmg'),
-    ({'application': 'devedition', 'platform': 'win32', 'version': '60.0b1', 'build_number': 1},
+    ({'application': 'devedition', 'platform': 'win32', 'version': '60.0b1', 'build_number': 3},
      'devedition/candidates/60.0b1-candidates/build3/win32/en-US/Firefox Setup 60.0b1.exe'),
-    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 1,
+    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 3,
       'locale': 'de'},
      'devedition/candidates/60.0b1-candidates/build3/mac/de/Firefox 60.0b1.dmg'),
-    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 1,
+    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 3,
       'extension': 'json'},
      'devedition/candidates/60.0b1-candidates/build3/mac/en-US/firefox-60.0b1.json'),
 ])


### PR DESCRIPTION
Now scraper fails when invalid build number is used instead of downloading other build

Fixes issue #445