### PR TITLE
Improved installation section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,14 @@ pip install mozdownload
 Otherwise follow the steps below to setup a development environment. It is
 recommended that [virtualenv](http://virtualenv.readthedocs.org/en/latest/installation.html)
 and [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/)
-be used in conjunction with mozdownload. Start by installing these. Then first fork
-our repository into your own github account, and run:
+be used in conjunction with mozdownload. Start by installing these,
+and [creating a virtualenv for the project](https://docs.python-guide.org/dev/virtualenvs/#lower-level-virtualenv).
+Then fork our repository into your own github account, and run:
 ```bash
 git clone https://github.com/%your_account%/mozdownload.git
 cd mozdownload
 python setup.py develop
 ```
-
-More detailed developer documentation can be found in the [wiki](https://github.com/mozilla/mozdownload/wiki).
 
 ## Command Line Usage
 


### PR DESCRIPTION
Removed obsolete link to wiki (does it still exist somewhere?) . Also added virtualenv commands because otherwise 'python setup.py develop' fails.

For me as a beginner it was confusing why 'python setup.py develop' fails when I followed instructions. With this change, installation process for a new contributer should go smoother :)