### PR TITLE
Upgrade syntax of setup.py to python 3.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read(*parts):
 
 
 def get_version():
-    return re.findall("__version__ = '([\d\.]+)'",
+    return re.findall(r"__version__ = '([\d\.]+)'",
                       read('mozdownload', 'cli.py'), re.M)[0]
 
 


### PR DESCRIPTION
This is a fix for #609 
Please take a look and let me know.

Checked with following command
```
find . -iname '*.py' | grep -Ev 'vendor|example|doc|tools|sphinx' | xargs -P4 -I{} python3.8 -Wall -m py_compile {}
```

No deprecation warning coming.