### PR TITLE
Temporarily pin packaging to version 31.3.0 due to removal of LegacyVersion

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,5 @@
 coveralls[yaml]==3.3.1
+packaging==21.3.0
 pytest==7.2.0
 pytest-cov==4.0.0
 pytest-mock==3.10.0


### PR DESCRIPTION
The [LegacyVersion](https://github.com/pypa/packaging/pull/407) class has been removed and that causes problems with our code. Before we will have a fix for it lets pin the package temporarily to version 21.3.0.

I filed https://github.com/mozilla/mozdownload/issues/635 to get the underlying issue fixed.