### PR TITLE
Replace packaging.LegacyVersion use with mozilla_version. Fixes #635

### DIFF
--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -33,6 +33,11 @@ APPLICATIONS_MULTI_LOCALE = ('fennec')
 APPLICATIONS_TO_FTP_DIRECTORY = {'fennec': 'mobile'}
 # Used if the application is named differently then the binary on the server
 APPLICATIONS_TO_BINARY_NAME = {'devedition': 'firefox'}
+# Used when sorting versions
+APPLICATIONS_TO_VERSION_CLASS = {'devedition': 'DeveditionVersion',
+                                 'firefox': 'FirefoxVersion',
+                                 'fennec': 'FennecVersion',
+                                 'thunderbird': 'ThunderbirdVersion'}
 
 # Base URL for the path to all builds
 BASE_URL = 'https://archive.mozilla.org/pub/'
@@ -668,8 +673,9 @@ class ReleaseScraper(Scraper):
         parser = self._create_directory_parser(url)
         if version:
             versions = parser.filter(RELEASE_AND_CANDIDATE_LATEST_VERSIONS[version])
-            from packaging.version import LegacyVersion
-            versions.sort(key=LegacyVersion)
+            from mozilla_version import gecko
+            MozVersion = getattr(gecko, APPLICATIONS_TO_VERSION_CLASS[self.application])
+            versions.sort(key=MozVersion.parse)
             return [versions[-1]]
         else:
             return parser.entries

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -78,8 +78,12 @@ RELEASE_AND_CANDIDATE_LATEST_VERSIONS = {
 
 
 def thunderbird_latest_version_filter(x):
-    invalid_versions = ("0.7rc", "1.0rc", "2.0.0.0", "2.0.0.0rc1", "10.0-real")
-    return x not in invalid_versions and\
+    """Ignore Thunderbird versions that mozilla-version does not accept as valid.
+       mozilla-version is only used to find the "latest" versions; these are old
+       and will not be relevant.
+    """
+    accepted_invalid_versions = ("0.7rc", "1.0rc", "2.0.0.0", "2.0.0.0rc1", "10.0-real")
+    return x not in accepted_invalid_versions and \
         re.match(RELEASE_AND_CANDIDATE_LATEST_VERSIONS['latest'], x)
 
 

--- a/mozdownload/scraper.py
+++ b/mozdownload/scraper.py
@@ -77,6 +77,18 @@ RELEASE_AND_CANDIDATE_LATEST_VERSIONS = {
 }
 
 
+def thunderbird_latest_version_filter(x):
+    invalid_versions = ("0.7rc", "1.0rc", "2.0.0.0", "2.0.0.0rc1", "10.0-real")
+    return x not in invalid_versions and\
+        re.match(RELEASE_AND_CANDIDATE_LATEST_VERSIONS['latest'], x)
+
+
+def latest_version_filter(version, application):
+    if application == "thunderbird" and version == "latest":
+        return thunderbird_latest_version_filter
+    return RELEASE_AND_CANDIDATE_LATEST_VERSIONS[version]
+
+
 class Scraper(object):
     """Generic class to download a Gecko based application."""
 
@@ -672,7 +684,7 @@ class ReleaseScraper(Scraper):
         url = urljoin(self.base_url, 'releases/')
         parser = self._create_directory_parser(url)
         if version:
-            versions = parser.filter(RELEASE_AND_CANDIDATE_LATEST_VERSIONS[version])
+            versions = parser.filter(latest_version_filter(version, self.application))
             from mozilla_version import gecko
             MozVersion = getattr(gecko, APPLICATIONS_TO_VERSION_CLASS[self.application])
             versions.sort(key=MozVersion.parse)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mozinfo >= 1.0.0
-packaging >= 19.0
 progressbar2 >= 3.34.3
 redo==2.0.4
 requests >= 2.21.0, <3.0.0
 treeherder-client >= 5.0.0, <6.0.0
+mozilla-version >= 1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mozinfo >= 1.0.0
+mozilla-version >= 1.2.0
 progressbar2 >= 3.34.3
 redo == 2.0.4
 requests >= 2.21.0, <3.0.0
 treeherder-client >= 5.0.0, <6.0.0
-mozilla-version >= 1.2.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,4 @@
 coveralls[yaml]==3.3.1
-packaging==21.3.0
 pytest==7.2.1
 pytest-cov==4.0.0
 pytest-mock==3.10.0


### PR DESCRIPTION
As packaging.LegacyVersion is gone, and packaging.Version produces too many errors, use the various version classes from mozilla_version.gecko when looking for the latest version of a supported application.