### PR TITLE
Fix packaging requirement for version 21.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mozinfo >= 1.0.0
-packaging >= 19.0
+packaging == 21.3.0
 progressbar2 >= 3.34.3
-redo==2.0.4
+redo == 2.0.4
 requests >= 2.21.0, <3.0.0
 treeherder-client >= 5.0.0, <6.0.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,4 @@
 coveralls[yaml]==3.3.1
-packaging==21.3.0
 pytest==7.2.2
 pytest-cov==4.0.0
 pytest-mock==3.10.0


### PR DESCRIPTION
None of the tests use the packaging module but mozdownload code itself. So my patch on #636 was actually wrong and this PR fixes it.