### PR TITLE
Bump minimal version of mozilla-version to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mozinfo >= 1.0.0
-mozilla-version >= 1.2.0
+mozilla-version >= 2.0.0
 progressbar2 >= 3.34.3
 redo == 2.0.4
 requests >= 2.21.0, <3.0.0


### PR DESCRIPTION
We switched to mozilla-version recently for version comparison. Before the 2.0.0 release the futures package got installed as dependency which is roughly 450KB in size. Since https://github.com/mozilla-releng/mozilla-version/issues/102 is fixed, this dependency is no longer needed.

As such we should always install version 2.0.0 or later.