### PR TITLE
Create GitHub Action to auto-publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,10 @@ jobs:
           toxenv: pylama
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,82 +7,47 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        # linux
-        - os: ubuntu-latest
-          python: "3.12"
-          toxenv: py312
-        - os: ubuntu-latest
-          python: "3.11"
-          toxenv: py311
-        - os: ubuntu-latest
-          python: "3.10"
-          toxenv: py310
-        - os: ubuntu-latest
-          python: "3.9"
-          toxenv: py39
-        - os: ubuntu-latest
-          python: "3.8"
-          toxenv: py38
-        # windows
-        - os: windows-latest
-          python: "3.12"
-          toxenv: py312
-        - os: windows-latest
-          python: "3.11"
-          toxenv: py311
-        - os: windows-latest
-          python: "3.10"
-          toxenv: py310
-        - os: windows-latest
-          python: "3.9"
-          toxenv: py39
-        - os: windows-latest
-          python: "3.8"
-          toxenv: py38
-        # macos
-        - os: macos-latest
-          python: "3.12"
-          toxenv: py312
-        - os: macos-latest
-          python: "3.11"
-          toxenv: py311
-        - os: macos-latest
-          python: "3.10"
-          toxenv: py310
-        - os: macos-latest
-          python: "3.9"
-          toxenv: py39
-        - os: macos-latest
-          python: "3.8"
-          toxenv: py38
-        # misc
-        - os: ubuntu-latest
-          python: "3.11"
-          toxenv: pylama
-
+    name: Build package
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: ${{ secrets.PYTHON_VERSION }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python ${{ vars.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ vars.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: python -m pip install -U build
 
       - name: Build package
-        run: python -m build    
+        run: python -m build
 
-      - name: Publish package to PyPI
-        if: github.repository == 'mozilla/mozdownload' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      - name: Upload dist folder
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist_directory
+          path: dist
+  
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      TOKEN: ${{ secrets.pypi_token }}
+    steps:
+      - name: Download dist folder
+        uses: actions/download-artifact@v4
+        id: download
+        with:
+          name: dist_directory
+          path: dist
+      - name: Publish package to PyPI 
+        if: steps.download.conclusion == 'success' && env.TOKEN != '' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ secrets.pypi_user }}
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.pypi_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # linux
+        - os: ubuntu-latest
+          python: "3.12"
+          toxenv: py312
+        - os: ubuntu-latest
+          python: "3.11"
+          toxenv: py311
+        - os: ubuntu-latest
+          python: "3.10"
+          toxenv: py310
+        - os: ubuntu-latest
+          python: "3.9"
+          toxenv: py39
+        - os: ubuntu-latest
+          python: "3.8"
+          toxenv: py38
+        # windows
+        - os: windows-latest
+          python: "3.12"
+          toxenv: py312
+        - os: windows-latest
+          python: "3.11"
+          toxenv: py311
+        - os: windows-latest
+          python: "3.10"
+          toxenv: py310
+        - os: windows-latest
+          python: "3.9"
+          toxenv: py39
+        - os: windows-latest
+          python: "3.8"
+          toxenv: py38
+        # macos
+        - os: macos-latest
+          python: "3.12"
+          toxenv: py312
+        - os: macos-latest
+          python: "3.11"
+          toxenv: py311
+        - os: macos-latest
+          python: "3.10"
+          toxenv: py310
+        - os: macos-latest
+          python: "3.9"
+          toxenv: py39
+        - os: macos-latest
+          python: "3.8"
+          toxenv: py38
+        # misc
+        - os: ubuntu-latest
+          python: "3.11"
+          toxenv: pylama
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: python -m pip install -U build
+
+      - name: Build package
+        run: python -m build    
+
+      - name: Publish package to PyPI
+        if: github.repository == 'mozilla/mozdownload' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.pypi_user }}
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools>=40']
+build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ['setuptools>=40']
-build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
- Configure repository secrets for user and password of PyPI authentication: ``user: ${{ secrets.pypi_user }}`` ``password: ${{ secrets.pypi_password }}``.
- Implement package uploads exclusively for tagged commits using the [gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish/blob/unstable/v1/README.md).
- Integrate the [isolation feature](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/) by adding the pyproject.toml file.
