### PR TITLE
Action to auto publish PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,48 +6,59 @@ on:
       - master
 
 jobs:
+  check-token:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token variable
+        env:
+          PYPI_TOKEN_VAR: ${{ secrets.pypi_token }}
+        run: |
+          if [ -z "$PYPI_TOKEN_VAR" ]; then
+            echo "Pypi token variable is empty!"
+            exit 1
+          fi
+          echo "Pypi token variable is set!"
   build:
     name: Build package
+    needs: check-token
     runs-on: ubuntu-latest
-    env:
-      PYTHON_VERSION: ${{ secrets.PYTHON_VERSION }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ vars.PYTHON_VERSION }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ vars.PYTHON_VERSION }}
+          python-version: 3.12
 
       - name: Install dependencies
         run: python -m pip install -U build
 
-      - name: Build package
+      - name: Build a binary wheel and a source tarball
         run: python -m build
 
-      - name: Upload dist folder
+      - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
-          name: dist_directory
+          name: python-package-distributions
           path: dist
   
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    needs: build
-    env:
-      TOKEN: ${{ secrets.pypi_token }}
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mozdownload
+    permissions:
+      id-token: write
+    needs: [check-token, build]
     steps:
       - name: Download dist folder
         uses: actions/download-artifact@v4
-        id: download
         with:
-          name: dist_directory
+          name: python-package-distributions
           path: dist
-      - name: Publish package to PyPI 
-        if: steps.download.conclusion == 'success' && env.TOKEN != '' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      - name: Upload release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.pypi_user }}
-          repository-url: https://test.pypi.org/legacy/
+          packages_dir: dist/
           password: ${{ secrets.pypi_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     environment:
       name: release
       url: https://pypi.org/p/mozdownload
@@ -32,8 +32,4 @@ jobs:
 
       - name: Upload release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-  on-failure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - run: echo "Test has failed"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,14 @@ on:
       - master
 
 jobs:
-  check-token:
+  deploy:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-    steps:
-      - name: Check token variable
-        env:
-          PYPI_TOKEN_VAR: ${{ secrets.pypi_token }}
-        run: |
-          if [ -z "$PYPI_TOKEN_VAR" ]; then
-            echo "Pypi token variable is empty!"
-            exit 1
-          fi
-          echo "Pypi token variable is set!"
-  build:
-    name: Build package
-    needs: check-token
-    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/mozdownload
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -36,29 +28,5 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python -m build
 
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist
-  
-  pypi-publish:
-    name: Upload release to PyPI
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/mozdownload
-    permissions:
-      id-token: write
-    needs: [check-token, build]
-    steps:
-      - name: Download dist folder
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist
       - name: Upload release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages_dir: dist/
-          password: ${{ secrets.pypi_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,10 @@ jobs:
           toxenv: pylama
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,4 @@ jobs:
       - name: Upload release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,16 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: [ Test ]
+    types: [ completed ]
+    branches: [ master ]
 
 jobs:
   deploy:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: release
       url: https://pypi.org/p/mozdownload
@@ -30,3 +32,8 @@ jobs:
 
       - name: Upload release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo "Test has failed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,82 +7,47 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        # linux
-        - os: ubuntu-latest
-          python: "3.12"
-          toxenv: py312
-        - os: ubuntu-latest
-          python: "3.11"
-          toxenv: py311
-        - os: ubuntu-latest
-          python: "3.10"
-          toxenv: py310
-        - os: ubuntu-latest
-          python: "3.9"
-          toxenv: py39
-        - os: ubuntu-latest
-          python: "3.8"
-          toxenv: py38
-        # windows
-        - os: windows-latest
-          python: "3.12"
-          toxenv: py312
-        - os: windows-latest
-          python: "3.11"
-          toxenv: py311
-        - os: windows-latest
-          python: "3.10"
-          toxenv: py310
-        - os: windows-latest
-          python: "3.9"
-          toxenv: py39
-        - os: windows-latest
-          python: "3.8"
-          toxenv: py38
-        # macos
-        - os: macos-latest
-          python: "3.12"
-          toxenv: py312
-        - os: macos-latest
-          python: "3.11"
-          toxenv: py311
-        - os: macos-latest
-          python: "3.10"
-          toxenv: py310
-        - os: macos-latest
-          python: "3.9"
-          toxenv: py39
-        - os: macos-latest
-          python: "3.8"
-          toxenv: py38
-        # misc
-        - os: ubuntu-latest
-          python: "3.11"
-          toxenv: pylama
-
+    name: Build package
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: ${{ secrets.PYTHON_VERSION }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python ${{ vars.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ vars.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: python -m pip install -U build
 
       - name: Build package
-        run: python -m build    
+        run: python -m build
 
-      - name: Publish package to PyPI
-        if: github.repository == 'mozilla/mozdownload' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      - name: Upload dist folder
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist_directory
+          path: dist
+  
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      TOKEN: ${{ secrets.pypi_token }}
+    steps:
+      - name: Download dist folder
+        uses: actions/download-artifact@v4
+        id: download
+        with:
+          name: dist_directory
+          path: dist
+      - name: Publish package to PyPI 
+        if: steps.download.conclusion == 'success' && env.TOKEN != '' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ secrets.pypi_user }}
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.pypi_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # linux
+        - os: ubuntu-latest
+          python: "3.12"
+          toxenv: py312
+        - os: ubuntu-latest
+          python: "3.11"
+          toxenv: py311
+        - os: ubuntu-latest
+          python: "3.10"
+          toxenv: py310
+        - os: ubuntu-latest
+          python: "3.9"
+          toxenv: py39
+        - os: ubuntu-latest
+          python: "3.8"
+          toxenv: py38
+        # windows
+        - os: windows-latest
+          python: "3.12"
+          toxenv: py312
+        - os: windows-latest
+          python: "3.11"
+          toxenv: py311
+        - os: windows-latest
+          python: "3.10"
+          toxenv: py310
+        - os: windows-latest
+          python: "3.9"
+          toxenv: py39
+        - os: windows-latest
+          python: "3.8"
+          toxenv: py38
+        # macos
+        - os: macos-latest
+          python: "3.12"
+          toxenv: py312
+        - os: macos-latest
+          python: "3.11"
+          toxenv: py311
+        - os: macos-latest
+          python: "3.10"
+          toxenv: py310
+        - os: macos-latest
+          python: "3.9"
+          toxenv: py39
+        - os: macos-latest
+          python: "3.8"
+          toxenv: py38
+        # misc
+        - os: ubuntu-latest
+          python: "3.11"
+          toxenv: pylama
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: python -m pip install -U build
+
+      - name: Build package
+        run: python -m build    
+
+      - name: Publish package to PyPI
+        if: github.repository == 'mozilla/mozdownload' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.pypi_user }}
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools>=40']
+build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ['setuptools>=40']
-build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Fixes https://github.com/mozilla/mozdownload/issues/669.

Thank you for reviewing my latest pull request, and I've made improvements in the following ways:
1. `pypa/gh-action-pypi-publish@release/v1` accepts either a password or PyPI token. Utilize the token instead of the user's password also i change the variable name to `pypi_token`.
2. Added a secret variable for specifying the Python version. Referring to the documentation of  `actions/setup-python@v5` , I've set it to '3.11.9', aligning with the available Python versions for that GitHub Action.
3. Implemented the use of artifacts to transfer the 'dist' folder between jobs (actions/download-artifact@v4, actions/upload-artifact@v4).
4. Set condition for publishing, ensuring the last step succeeds, the secret is not empty, and the event is push and is a 
tagged commit.