### PR TITLE
Move DevEdition remote tests from Firefox 60.0 to 128.0

### DIFF
--- a/tests/remote/test_devedition.py
+++ b/tests/remote/test_devedition.py
@@ -16,18 +16,18 @@ from mozdownload.utils import urljoin
 
 @pytest.mark.ci_only
 @pytest.mark.parametrize("args,url", [
-    ({'application': 'devedition', 'platform': 'linux', 'version': '60.0b1'},
-     'devedition/releases/60.0b1/linux-i686/en-US/firefox-60.0b1.tar.bz2'),
-    ({'application': 'devedition', 'platform': 'linux64', 'version': '60.0b1'},
-     'devedition/releases/60.0b1/linux-x86_64/en-US/firefox-60.0b1.tar.bz2'),
-    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1'},
-     'devedition/releases/60.0b1/mac/en-US/Firefox 60.0b1.dmg'),
-    ({'application': 'devedition', 'platform': 'win32', 'version': '60.0b1'},
-     'devedition/releases/60.0b1/win32/en-US/Firefox Setup 60.0b1.exe'),
-    ({'application': 'devedition', 'platform': 'win64', 'version': '60.0b1'},
-     'devedition/releases/60.0b1/win64/en-US/Firefox Setup 60.0b1.exe'),
-    ({'application': 'devedition', 'platform': 'win32', 'version': '60.0b1', 'locale': 'de'},
-     'devedition/releases/60.0b1/win32/de/Firefox Setup 60.0b1.exe'),
+    ({'application': 'devedition', 'platform': 'linux', 'version': '128.0b1'},
+     'devedition/releases/128.0b1/linux-i686/en-US/firefox-128.0b1.tar.bz2'),
+    ({'application': 'devedition', 'platform': 'linux64', 'version': '128.0b1'},
+     'devedition/releases/128.0b1/linux-x86_64/en-US/firefox-128.0b1.tar.bz2'),
+    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1'},
+     'devedition/releases/128.0b1/mac/en-US/Firefox 128.0b1.dmg'),
+    ({'application': 'devedition', 'platform': 'win32', 'version': '128.0b1'},
+     'devedition/releases/128.0b1/win32/en-US/Firefox Setup 128.0b1.exe'),
+    ({'application': 'devedition', 'platform': 'win64', 'version': '128.0b1'},
+     'devedition/releases/128.0b1/win64/en-US/Firefox Setup 128.0b1.exe'),
+    ({'application': 'devedition', 'platform': 'win32', 'version': '128.0b1', 'locale': 'de'},
+     'devedition/releases/128.0b1/win32/de/Firefox Setup 128.0b1.exe'),
 ])
 def test_release_scraper(tmpdir, args, url):
     """Test release scraper against the remote server."""
@@ -39,20 +39,20 @@ def test_release_scraper(tmpdir, args, url):
 
 @pytest.mark.ci_only
 @pytest.mark.parametrize("args,url", [
-    ({'application': 'devedition', 'platform': 'linux', 'version': '60.0b1', 'build_number': 3},
-     'devedition/candidates/60.0b1-candidates/build3/linux-i686/en-US/firefox-60.0b1.tar.bz2'),
-    ({'application': 'devedition', 'platform': 'linux64', 'version': '60.0b1', 'build_number': 3},
-     'devedition/candidates/60.0b1-candidates/build3/linux-x86_64/en-US/firefox-60.0b1.tar.bz2'),  # noqa
-    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 3},
-     'devedition/candidates/60.0b1-candidates/build3/mac/en-US/Firefox 60.0b1.dmg'),
-    ({'application': 'devedition', 'platform': 'win32', 'version': '60.0b1', 'build_number': 3},
-     'devedition/candidates/60.0b1-candidates/build3/win32/en-US/Firefox Setup 60.0b1.exe'),
-    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 3,
+    ({'application': 'devedition', 'platform': 'linux', 'version': '128.0b1', 'build_number': 3},
+     'devedition/candidates/128.0b1-candidates/build1/linux-i686/en-US/firefox-128.0b1.tar.bz2'),
+    ({'application': 'devedition', 'platform': 'linux64', 'version': '128.0b1', 'build_number': 3},
+     'devedition/candidates/128.0b1-candidates/build1/linux-x86_64/en-US/firefox-128.0b1.tar.bz2'),  # noqa
+    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 3},
+     'devedition/candidates/128.0b1-candidates/build1/mac/en-US/Firefox 128.0b1.dmg'),
+    ({'application': 'devedition', 'platform': 'win32', 'version': '128.0b1', 'build_number': 3},
+     'devedition/candidates/128.0b1-candidates/build1/win32/en-US/Firefox Setup 128.0b1.exe'),
+    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 3,
       'locale': 'de'},
-     'devedition/candidates/60.0b1-candidates/build3/mac/de/Firefox 60.0b1.dmg'),
-    ({'application': 'devedition', 'platform': 'mac', 'version': '60.0b1', 'build_number': 3,
+     'devedition/candidates/128.0b1-candidates/build1/mac/de/Firefox 128.0b1.dmg'),
+    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 3,
       'extension': 'json'},
-     'devedition/candidates/60.0b1-candidates/build3/mac/en-US/firefox-60.0b1.json'),
+     'devedition/candidates/128.0b1-candidates/build1/mac/en-US/firefox-128.0b1.json'),
 ])
 def test_candidate_scraper(tmpdir, args, url):
     """Test release candidate scraper against the remote server."""

--- a/tests/remote/test_devedition.py
+++ b/tests/remote/test_devedition.py
@@ -39,18 +39,18 @@ def test_release_scraper(tmpdir, args, url):
 
 @pytest.mark.ci_only
 @pytest.mark.parametrize("args,url", [
-    ({'application': 'devedition', 'platform': 'linux', 'version': '128.0b1', 'build_number': 3},
+    ({'application': 'devedition', 'platform': 'linux', 'version': '128.0b1', 'build_number': 1},
      'devedition/candidates/128.0b1-candidates/build1/linux-i686/en-US/firefox-128.0b1.tar.bz2'),
-    ({'application': 'devedition', 'platform': 'linux64', 'version': '128.0b1', 'build_number': 3},
+    ({'application': 'devedition', 'platform': 'linux64', 'version': '128.0b1', 'build_number': 1},
      'devedition/candidates/128.0b1-candidates/build1/linux-x86_64/en-US/firefox-128.0b1.tar.bz2'),  # noqa
-    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 3},
+    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 1},
      'devedition/candidates/128.0b1-candidates/build1/mac/en-US/Firefox 128.0b1.dmg'),
-    ({'application': 'devedition', 'platform': 'win32', 'version': '128.0b1', 'build_number': 3},
+    ({'application': 'devedition', 'platform': 'win32', 'version': '128.0b1', 'build_number': 1},
      'devedition/candidates/128.0b1-candidates/build1/win32/en-US/Firefox Setup 128.0b1.exe'),
-    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 3,
+    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 1,
       'locale': 'de'},
      'devedition/candidates/128.0b1-candidates/build1/mac/de/Firefox 128.0b1.dmg'),
-    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 3,
+    ({'application': 'devedition', 'platform': 'mac', 'version': '128.0b1', 'build_number': 1,
       'extension': 'json'},
      'devedition/candidates/128.0b1-candidates/build1/mac/en-US/firefox-128.0b1.json'),
 ])


### PR DESCRIPTION
Fixes #688.