### PR TITLE
Use "http" fixture per session to increase test runtime drasticallly

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+addopts = -vv --durations=5
+log_cli = 1
 markers =
     ci_only: Only run these tests within the CI environment.
-    
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
-import base64
 import os
 
 import pytest
-from urllib.parse import parse_qs, urlparse
 
 from wptserve import (
     handlers,
@@ -34,19 +32,22 @@ def basic_auth_handler(req, response):
         response.content = content.format("restricted")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def httpd():
     HERE = os.path.dirname(os.path.abspath(__file__))
+
     routes = [
         ("GET", "/basic_auth", basic_auth_handler),
     ]
     routes.extend(default_routes.routes)
+
     httpd = server.WebTestHttpd(
         host="127.0.0.1",
         port=0,
         doc_root=os.path.join(HERE, 'data'),
         routes=routes,
         )
+
     httpd.start()
     yield httpd
     httpd.stop()


### PR DESCRIPTION
I noticed that tests that are only using data from the local HTTP server are running very slow. After investigation it turned out that the HTTP server's shutdown method takes about 0.5s to run. I filed https://github.com/web-platform-tests/wpt/issues/46710 to get this investigated.

To workaround the issue we should use the `http` fixture per session and not per test. 