### PR TITLE
Update dependabot.yml to auto update github actions #702

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
   open-pull-requests-limit: 10
   allow:
     - dependency-type: all
+
+- package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -7,9 +13,3 @@ updates:
     open-pull-requests-limit: 10
     allow:
       - dependency-type: all
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: "pip"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  open-pull-requests-limit: 10
-  allow:
-    - dependency-type: all
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: all
 
-- package-ecosystem: "github-actions"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Fixes #702.

Hello! This change would automatically update GitHub Actions like actions/checkout@v3 to the latest version whenever a new version is released.

If we only want to update specific GitHub actions, we can specify it like this:
```
allow:
  - dependency-name: "actions/checkout"
  - dependency-name: "actions/setup-python"
```