### PR TITLE
Release version 1.30.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+# Version History
+
+## 1.30.0 / 2025-05-26
+
+* Update release action to get triggered from a new tag being created. (#718)
+* Add Python 3.13 to GitHub actions and move to Codecov (#716)
+* Remove support for Tinderbox scraper (#714)
+
 ## 1.29.0 / 2024-12-11
 
 * Default to "tar.xz" archive file format for Linux (#709)

--- a/mozdownload/cli.py
+++ b/mozdownload/cli.py
@@ -15,7 +15,7 @@ import sys
 
 from mozdownload import factory, scraper
 
-__version__ = '1.29.0'
+__version__ = '1.30.0'
 
 
 def parse_arguments(argv):


### PR DESCRIPTION
Updates history and setup.py for the 1.30.0 release. It's required for #719.

@lutien or @juliandescottes can one of you please review? Thanks.