### PR TITLE
Revert "Update release action to get triggered from a new tag being created. (#718)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,13 @@ on:
   workflow_run:
     workflows: [ Test ]
     types: [ completed ]
+    branches: [ master ]
 
 jobs:
   deploy:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    if: >
-      ${{ github.event.workflow_run.conclusion == 'success' &&
-          startsWith(github.event.workflow_run.head_branch, 'refs/tags/') == false }}  # we'll check tag inside
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     environment:
       name: release
       url: https://pypi.org/p/mozdownload
@@ -19,24 +18,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Ensure it's a new release # tag created
-        id: tag-check
-        run: |
-          TAG=$(git describe --tags --exact-match 2>/dev/null || true)
-          if [[ -z "$TAG" ]]; then
-            echo "Not a tag commit. Skipping release."
-            exit 1
-          fi
-          echo "Release tag: $TAG"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Python 3.13
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: 3.12
 
       - name: Install dependencies
         run: python -m pip install -U build


### PR DESCRIPTION
This reverts commit b60d87e1bd38f8810b04018a8c0caa88171be1e4.

For details see https://github.com/mozilla/mozdownload/issues/669#issuecomment-2909532652.